### PR TITLE
What changed:

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,190 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+pyrust-bt is a hybrid backtesting framework that combines Python for strategy development with Rust for high-performance execution. The framework is designed for quantitative trading research and small-team production use, balancing researcher productivity with engine throughput.
+
+## Architecture
+
+### Core Components
+
+- **Rust Engine** (`rust/engine_rust/`): High-performance backtesting core with PyO3 bindings
+  - Time-based advancement over bars/ticks
+  - Order matching (market/limit with same-bar simplified execution)
+  - Portfolio management with position tracking
+  - Vectorized indicators (SMA, RSI) optimized for sliding windows
+  - Enhanced statistics and performance metrics
+  - Batch processing for reduced Python round-trips
+
+- **Python API** (`python/pyrust_bt/`): User-facing interface for strategy development
+  - `Strategy` base class with lifecycle methods (`on_start`, `next`, `on_stop`, `on_order`, `on_trade`)
+  - Data loading utilities (CSV support, extensible to Parquet/Arrow)
+  - Analysis tools for drawdowns, round-trips, performance metrics
+  - Grid search optimizer for parameter tuning
+  - Multi-asset backtesting support via `run_multi()` method
+
+- **Examples** (`examples/`): Demonstrations of framework usage
+  - Basic backtesting (`run_mvp.py`)
+  - Advanced analysis (`run_analyzers.py`)
+  - Parameter optimization (`run_grid_search.py`)
+  - Performance testing (`run_performance_test.py`)
+  - Multi-asset backtesting (`run_multi_assets.py`)
+  - External holdings support (`run_external_holdings.py`)
+
+- **Web Interface**: FastAPI backend with Streamlit frontend for remote backtesting
+
+## Build System
+
+### Prerequisites
+- Python 3.8+
+- Rust (installed via `rustup`)
+- `maturin` for building Rust extensions
+
+### Build Commands
+```powershell
+# Build the Rust engine
+cd rust/engine_rust
+maturin develop --release
+
+# Alternative: Install in development mode
+pip install maturin
+maturin develop
+```
+
+### Running Examples
+```powershell
+# Basic backtest
+python examples/run_mvp.py
+
+# Analysis with enhanced metrics
+python examples/run_analyzers.py
+
+# Grid search optimization
+python examples/run_grid_search.py
+
+# Performance benchmarking
+python examples/run_performance_test.py
+
+# Multi-asset backtesting
+python examples/run_multi_assets.py
+```
+
+### Starting Web Services
+```powershell
+# API server (FastAPI)
+python -m uvicorn python.server_main:app --reload
+
+# Frontend (Streamlit) - set API endpoint first
+set PYRUST_BT_API=http://127.0.0.1:8000
+streamlit run frontend/streamlit_app.py
+```
+
+## Key Design Patterns
+
+### Strategy Implementation
+Strategies extend the `Strategy` base class and implement the `next()` method:
+
+```python
+class MyStrategy(Strategy):
+    def __init__(self, param1: float = 1.0):
+        self.param1 = param1
+
+    def next(self, bar: Dict[str, Any]) -> Optional[Union[str, Dict[str, Any]]]:
+        # Return "BUY"/"SELL" strings or detailed action dicts
+        return {"action": "BUY", "type": "market", "size": 1.0}
+```
+
+### Action Format
+- String format: `"BUY"` or `"SELL"` (market orders, size=1)
+- Dict format: `{"action": "BUY"|"SELL", "type": "market"|"limit", "size": float, "price"?: float}`
+
+### Multi-Asset Support
+Use `run_multi()` with feeds dictionary:
+```python
+feeds = {
+    "asset1": bars1,
+    "asset2": bars2,
+}
+result = engine.run_multi(strategy, feeds)
+```
+
+## Performance Optimization
+
+### Batch Processing
+The Rust engine uses configurable `batch_size` (default: 1000) to reduce Python GIL contention. Larger batches (1000-5000) are recommended for better performance.
+
+### Vectorized Indicators
+Prefer Rust-based indicators over Python implementations:
+```python
+from pyrust_bt import compute_sma, compute_rsi
+sma_values = compute_sma(prices, window=20)
+rsi_values = compute_rsi(prices, window=14)
+```
+
+### Data Format
+For optimal performance with large datasets:
+- Use Parquet/Arrow formats when possible
+- Partition data by symbol and time
+- Pre-allocate buffers and use columnar processing
+
+## Data Structure
+
+### Bar Data Format
+Expected columns: `datetime,open,high,low,close,volume`
+Optional: `symbol` (for multi-asset backtesting)
+
+### Result Structure
+Backtest results contain:
+- Portfolio state: `cash`, `position`, `avg_cost`, `equity`, `realized_pnl`
+- Time series: `equity_curve`, `trades`
+- Statistics: performance metrics, drawdown analysis, trade statistics
+
+## Common Issues
+
+### Build Failures
+- Ensure Rust toolchain is up to date: `rustup update`
+- Clean build artifacts: `maturin build --release` after `cargo clean`
+- Check Python-Rust version compatibility in `Cargo.toml`
+
+### Import Errors
+- The Rust extension must be built before importing: `maturin develop --release`
+- Verify the Python path includes the project root
+
+### Performance Bottlenecks
+- Increase `batch_size` in BacktestConfig for better throughput
+- Use dict actions instead of strings for complex order types
+- Leverage Rust vectorized functions when possible
+
+## Testing Strategy
+
+### Unit Tests
+- Test individual strategy logic in isolation
+- Validate indicator calculations against known results
+- Check edge cases for order matching and position updates
+
+### Integration Tests
+- End-to-end backtesting with sample data
+- Multi-asset scenario validation
+- Performance regression testing
+
+### Benchmarking
+Use `run_performance_test.py` to measure:
+- Bars per second processing rate
+- Memory usage patterns
+- Scaling with different batch sizes
+
+## Extension Points
+
+### Custom Indicators
+Add new indicators to `rust/engine_rust/src/lib.rs` and expose via PyO3.
+
+### Data Sources
+Extend `python/pyrust_bt/data.py` to support additional formats (Parquet, Arrow, databases).
+
+### Analysis Tools
+Add new analyzers in `python/pyrust_bt/analyzers.py` for specialized metrics.
+
+### Order Types
+Implement additional order types (stop, iceberg, conditional) in the Rust engine.

--- a/README.md
+++ b/README.md
@@ -1,251 +1,180 @@
 # pyrust-bt
 
-<div  align="center">
-<img src="images/logo.jpeg" width = "200" height = "200" alt="" align=center />
+<div align="center">
+  <img src="images/logo.jpeg" width="180" height="180" alt="pyrust-bt logo" />
 </div>
 
-A hybrid backtesting framework: Python for strategy and data, Rust for the high-performance core via PyO3 bindings. Designed to balance researcher productivity with engine throughput, suitable from research to small-team production.
+pyrust-bt is a hybrid backtesting framework for quantitative research: Python for strategy development and data workflows, Rust for high-performance execution through PyO3 bindings.
 
-[中文文档 | Chinese README](README.zh-CN.md)
+[Chinese README](README.zh-CN.md) | [Documentation](docs/index.md) | [Examples](docs/examples.md)
 
-## Features
+## Why pyrust-bt
 
-- Rust Engine
-  - Time advancement over bars/ticks
-  - Order matching: market/limit (same-bar simplified execution)
-  - Cost model: commission `commission_rate`, slippage `slippage_bps`
-  - Portfolio & ledger: `position / avg_cost / cash / equity / realized_pnl`
-  - Vectorized indicators: `SMA / RSI` (sliding window optimized)
-  - Statistics: total return, annualized return, volatility, Sharpe, Calmar, max drawdown & duration
-  - Performance: batch processing (`batch_size`), pre-extracted data, preallocated buffers, inlined hot paths
+- Write strategies in Python with a small lifecycle API.
+- Run the hot path in Rust: bar iteration, order matching, portfolio state, indicators, and statistics.
+- Use CSV for quick experiments, or DuckDB as a local market data store.
+- Move from single-asset tests to multi-asset portfolio simulations.
+- Analyze results with drawdowns, round trips, performance metrics, factor tests, and quantile portfolios.
 
-- Python API
-  - Strategy lifecycle: `on_start` → `next(bar)` → `on_stop` with `on_order / on_trade` callbacks
-  - Action format:
-    - String: `"BUY" | "SELL"`
-    - Dict: `{ "action": "BUY"|"SELL", "type": "market"|"limit", "size": float, "price"?: float }`
-  - Data loader: CSV → list[dict] (MVP; pluggable for Parquet/Arrow)
-  - Analyzers: drawdown segments, round-trips, enhanced performance metrics, factor backtests (quantiles/IC/monotonicity), unified report
-  - **Cross-sectional Factor Analysis**: multi-factor evaluation system, quantile portfolio backtesting, IC/ICIR analysis, factor ranking
-  - Optimizer: naive grid search (customizable scoring key)
+## Quick Start
 
-- API & Frontend
-  - FastAPI: `POST /runs`, `GET /runs`, `GET /runs/{id}`
-  - Streamlit: submit runs, list & visualize results (equity curve + stats)
-
-## Install & Build
-
-Prereqs: Python 3.8+, Rust (`rustup`), maturin
+Prerequisites: Python 3.8+, Rust, and `maturin`.
 
 ```powershell
 pip install maturin
 cd rust/engine_rust
-
-# Option A: Install directly into the active Python environment (best for local dev)
 maturin develop --release
-
-# Option B: Build wheel only, install manually afterwards
-python -m maturin build --release
-pip install --force-reinstall (Get-ChildItem target/wheels/engine_rust-*.whl | Select-Object -First 1).FullName
+cd ../..
+python examples/run_mvp.py
 ```
 
-## Quick Start
+The Rust extension must be built before importing `pyrust_bt.api.BacktestEngine`.
 
-- Minimal backtest
+## Minimal Example
 
-  ```powershell
-  cd ../..
-  python examples/run_mvp.py
-  ```
+When running your own script from the repository root, set `PYTHONPATH=python` or add the `python/` directory to `sys.path`.
 
-- Local DuckDB data flow
+```python
+from pyrust_bt.api import BacktestConfig, BacktestEngine
+from pyrust_bt.data import load_csv_to_bars
+from pyrust_bt.strategy import Strategy
 
-  ```powershell
-  # build the Rust extension once
-  cd rust/engine_rust
-  maturin develop --release
 
-  # import CSV candles into the bundled DuckDB (writes to data/backtest.db by default)
-  cd ../..
-  python examples/import_csv_to_db.py --csv examples/data/sh600000_min.csv --symbol 600000.sh --period 1m
+class BreakoutStrategy(Strategy):
+    def next(self, bar):
+        if bar["close"] > bar["open"]:
+            return {"action": "BUY", "type": "market", "size": 1.0}
+        return {"action": "SELL", "type": "market", "size": 1.0}
 
-  # run the DB-backed example (reads from data/backtest.db)
-  python examples/run_mvp_db.py
-  ```
 
-- Analyzer demo
+cfg = BacktestConfig(
+    start="2020-01-01",
+    end="2025-12-31",
+    cash=100000.0,
+    commission_rate=0.0005,
+    slippage_bps=2.0,
+    batch_size=1000,
+)
 
-  ```powershell
-  python examples/run_analyzers.py
-  ```
+bars = load_csv_to_bars("examples/data/sample.csv", symbol="SAMPLE")
+result = BacktestEngine(cfg).run(BreakoutStrategy(), bars)
 
-- Grid search
+print(result["stats"])
+```
 
-  ```powershell
-  python examples/run_grid_search.py
-  ```
+## Learning Path
 
-- Cross-sectional factor backtesting
+| Step | Topic | Guide |
+|---|---|---|
+| 1 | Install and build the Rust extension | [Getting Started](docs/getting-started.md) |
+| 2 | Run the first backtest | [Getting Started](docs/getting-started.md) |
+| 3 | Write strategies and actions | [Strategy Guide](docs/strategy-guide.md) |
+| 4 | Understand the engine model | [Architecture](docs/architecture.md) |
+| 5 | Pick the right demo | [Examples](docs/examples.md) |
+| 6 | Use DuckDB and QMT data | [Market Data](docs/market-data.md) |
+| 7 | Run factor research workflows | [Factor Analysis](docs/factor-analysis.md) |
+| 8 | Fix build and import issues | [Troubleshooting](docs/troubleshooting.md) |
 
-  ```powershell
-  python examples/run_cs_momentum_sample.py
-  ```
+## Features
 
-- Quantile portfolio backtesting with trading simulation
+| Area | What is included |
+|---|---|
+| Rust engine | Bar iteration, market and limit orders, cost model, portfolio state, equity curve, statistics |
+| Python API | Strategy lifecycle, data loading, analyzers, grid search, multi-asset entry point |
+| Indicators | Rust vectorized SMA and RSI, Python SMA fallback |
+| Multi-asset | `run_multi()` with per-symbol feeds and `next_multi(update_slice, ctx)` |
+| Market data | CSV loading, DuckDB persistence, optional QMT / xtdata backfill |
+| Factor research | IC, rank IC, monotonicity, factor ranking, quantile portfolio backtests |
+| Web UI | FastAPI run service and Streamlit result viewer |
 
-  ```powershell
-  python examples/run_cs_quantile_portfolios.py
-  ```
+## Architecture
 
-- Performance test & batch-size comparison
+```mermaid
+flowchart LR
+    A["CSV / DuckDB / QMT"] --> B["Python data layer"]
+    B --> C["Python strategy"]
+    C --> D["Rust backtest engine"]
+    D --> E["Order matching"]
+    D --> F["Portfolio state"]
+    D --> G["Equity curve / trades / stats"]
+    G --> H["Analyzers"]
+    G --> I["FastAPI / Streamlit"]
+```
 
-  ```powershell
-  python examples/run_performance_test.py
-  ```
+Read the full architecture notes in [docs/architecture.md](docs/architecture.md).
 
-Sample data: `examples/data/sample.csv` (headers: `datetime,open,high,low,close,volume`).
+## Example Index
 
-## Market Data: DuckDB + QMT
+| Example | Command | Purpose |
+|---|---|---|
+| Minimal single-asset backtest | `python examples/run_mvp.py` | First smoke test |
+| Analysis report | `python examples/run_analyzers.py` | Drawdowns, round trips, metrics |
+| Grid search | `python examples/run_grid_search.py` | Parameter scanning |
+| Multi-asset SMA | `python examples/run_multi_assets.py` | Basic `run_multi()` usage |
+| DuckDB CSV import | `python examples/import_csv_to_db.py --help` | Local market data store |
+| QMT-backed rebalance | `python examples/run_multi_asset_rebalance_strategy.py` | DB-first data with xtdata fallback |
+| Cross-sectional factor sample | `python examples/run_cs_momentum_sample.py` | Factor ranking workflow |
+| Quantile portfolios | `python examples/run_cs_quantile_portfolios.py` | Factor portfolio simulation |
+| Performance benchmark | `python examples/run_performance_test.py` | Batch-size and speed checks |
 
-### DuckDB Local Store
+See [docs/examples.md](docs/examples.md) for when to use each example.
 
-- The default database lives at `data/backtest.db`, but you can point scripts to any DuckDB file via `--db`.
-- Bulk-import historical data:
+## Engine Model
 
-  ```powershell
-  # Write CSV directly into DuckDB (requires the compiled engine_rust extension)
-  python examples/import_csv_to_db.py data/513500_d.csv --symbol 513500.SH --period 1d --db data/backtest.db
-  ```
+The current matching model is intentionally simple and research-oriented:
 
-- Use `--no-direct-csv` to parse the CSV in Python first (useful for inspection) before saving through Rust.
-- Internally `save_klines` / `save_klines_from_csv` persist to the canonical schema; feel free to inspect the DB with `duckdb` CLI or any DuckDB-compatible tool.
+- Market orders fill on the current bar close.
+- Limit orders use same-bar simplified execution.
+- Commission and slippage are applied during fills.
+- The engine tracks cash, position, average cost, equity, realized PnL, trades, and statistics.
 
-### Zero-Maintenance QMT / XtData Backfill
-
-- When the local DuckDB store misses date ranges, `MarketDataService` can call QMT Mini (xtdata) to download the gap and write it back, achieving a “DB first → auto backfill” workflow.
-- Preparation checklist:
-  1. Install the `XtQuant` Python package by copying it into your interpreter’s `site-packages`, e.g. `D:\ProgramData\miniconda3\Lib\site-packages` (adjust to your environment).
-  2. Verify `import XtQuant.XtData` works in Python.
-  3. Set the `XTDATA_DIR` environment variable to the MiniQmt `userdata_mini` directory (default in examples: `D:\国金证券QMT交易端\userdata_mini`).
-- Run the multi-asset equal-weight example to smoke-test the data pipeline:
-
-  ```powershell
-  python examples/run_multi_asset_rebalance_strategy.py
-  ```
-
-- See `doc/xtdata_market_data_plan.md` for architecture details and operational recommendations.
-
-## In Code
-
-- Config & engine
-
-  ```python
-  from pyrust_bt.api import BacktestEngine, BacktestConfig
-  cfg = BacktestConfig(start="2020-01-01", end="2020-12-31", cash=100000,
-                       commission_rate=0.0005, slippage_bps=2.0, batch_size=1000)
-  engine = BacktestEngine(cfg)
-  ```
-
-- Strategy (minimal)
-
-  ```python
-  from pyrust_bt.strategy import Strategy
-  class MyStrategy(Strategy):
-      def next(self, bar):
-          if bar["close"] > 100:
-              return {"action": "BUY", "type": "market", "size": 1.0}
-          return None
-  ```
-
-- Run
-
-  ```python
-  from pyrust_bt.data import load_csv_to_bars
-  bars = load_csv_to_bars("examples/data/sample.csv", symbol="SAMPLE")
-  result = engine.run(MyStrategy(), bars)
-  print(result["stats"], result["equity"])  # stats & equity
-  ```
-
-## Analysis & Reports
-
-- Drawdown segments: `compute_drawdown_segments(equity_curve)`
-- Round trips: `round_trips_from_trades(trades, bars)` / export CSV
-- Performance metrics: `compute_performance_metrics(equity_curve)` (Sharpe/Sortino/Calmar/VAR)
-- Factor backtest: `factor_backtest(bars, factor_key, quantiles, forward)`
-- Unified report: `generate_analysis_report(...)`
-- **Cross-sectional Factor Evaluation**:
-  - Multi-factor analyzer: `MultiFactorAnalyzer` with time-series/cross-sectional methods
-  - Factor ranking: IC, ICIR, monotonicity, stability, turnover analysis
-  - Quantile portfolio backtesting: `CrossSectionFactorBacktester` for large-scale factor evaluation
-  - Export: detailed reports, factor rankings, correlation matrices
-
-## API & Frontend
-
-- Start API (FastAPI)
-
-  ```powershell
-  pip install fastapi uvicorn pydantic requests streamlit
-  python -m uvicorn python.server_main:app --reload
-  ```
-
-- Start frontend (Streamlit)
-
-  ```powershell
-  set PYRUST_BT_API=http://127.0.0.1:8000
-  streamlit run frontend/streamlit_app.py
-  ```
-
-## Performance Notes
-
-- Prefer larger `batch_size` (e.g., 1000–5000) to reduce Python round-trips
-- Prefer dict actions over strings
-- Use Rust vectorized indicators (`compute_sma/compute_rsi`) when possible
-- For large data, prefer Parquet/Arrow and partitioned reads (by symbol/time)
+Advanced market microstructure features such as order books, partial fills, stop orders, OCO orders, and persistent pending orders are planned extension points.
 
 ## Project Structure
 
-- `rust/engine_rust`: Rust engine (PyO3), indicators & stats
-- `python/pyrust_bt`: Python API/strategy/data/analyzers/optimizer
-- `python/pyrust_bt/multi_factor_analyzer.py`: Multi-factor evaluation system
-- `python/pyrust_bt/cs_factor_backtester.py`: Cross-sectional factor backtesting
-- `examples`: MVP, analyzers, grid search, performance tests
-- `examples/run_cs_momentum_sample.py`: Cross-sectional momentum factor demo
-- `examples/run_cs_quantile_portfolios.py`: Quantile portfolio trading simulation
-- `frontend`: Streamlit UI
+```text
+python/pyrust_bt/          Python API, strategy base class, analyzers, optimizer
+python/server_main.py      FastAPI run service
+frontend/streamlit_app.py  Streamlit frontend
+rust/engine_rust/          Rust PyO3 extension and DuckDB data functions
+examples/                  Runnable demos and research workflows
+docs/                      User guides and technical documentation
+doc/                       Product notes and historical design notes
+```
 
-## TODO / Roadmap
+## Web UI
 
-- Engine/Matching
-  - Partial fills, order book, stop/take-profit, OCO, conditional orders
-  - Multi-asset/multi-timeframe alignment, calendar/timezone
-  - Liquidity/impact models
-- Data
-  - Parquet/Arrow zero-copy pipelines, columnar batching
-  - DataFeed abstraction (DB/object storage) & caching
-- Analysis/Reports
-  - Rich analyzers (group stats, drawdown visualization, trade distributions)
-  - Report export (PDF/HTML) & multi-run comparison
-  - Advanced factor analysis (industry/market cap neutralization, rolling quantiles)
-- Optimization/Parallelism
-  - Random/Bayesian search, cross-validation
-  - Multi-process/distributed runs (Ray/Celery/k8s Jobs)
-- Frontend/UX
-  - React + ECharts/Plotly (task mgmt, playback, filters, annotations)
-  - WebSocket live logs/progress/equity
-- Quality/Eng
-  - Unit/integration/regression tests, benchmarks
-  - CI (wheel build/artifacts), releases
+```powershell
+pip install fastapi uvicorn pydantic requests streamlit
+python -m uvicorn python.server_main:app --reload
+```
 
-## 🚀 Performance Highlights
+In another terminal:
 
-- Backtest speed: from 1,682 bars/s to **419,552 bars/s** (≈250×)
-- Dataset: 550k bars in ~1.3s
-- Memory: preallocated buffers to reduce reallocations
-- Batching: configurable `batch_size` to reduce GIL contention
+```powershell
+set PYRUST_BT_API=http://127.0.0.1:8000
+streamlit run frontend/streamlit_app.py
+```
+
+## Performance Notes
+
+- Use `batch_size=1000` to `5000` for large runs.
+- Prefer Rust vectorized functions such as `compute_sma()` and `compute_rsi()`.
+- Keep large datasets in columnar or database-backed formats when possible.
+- Use the performance example before changing engine internals.
+
+## Roadmap
+
+- Matching: partial fills, order book simulation, stop and conditional orders.
+- Data: Parquet / Arrow pipelines, stronger data feed abstraction, caching.
+- Analysis: richer reports, multi-run comparison, HTML / PDF export.
+- Optimization: random search, Bayesian search, parallel execution.
+- Web: richer visualization, persisted runs, live progress updates.
+- Quality: unit tests, integration tests, benchmarks, CI wheel builds.
 
 ## Community
 
-Pull requests are welcome!
+Pull requests and issue reports are welcome.
 
 ![Join](images/yzbjs1.png)
 
@@ -255,4 +184,4 @@ MIT
 
 ## Disclaimer
 
-This tool is for research and education only and does not constitute investment advice. You are solely responsible for your trading decisions and associated risks.
+This project is for research and education only. It is not investment advice. You are responsible for your own trading decisions and risk management.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+pyrust-bt separates research ergonomics from execution speed. Python owns the user-facing API and strategy code. Rust owns the hot path.
+
+## System Overview
+
+```mermaid
+flowchart LR
+    A["CSV files"] --> B["Python data utilities"]
+    C["DuckDB"] --> D["Rust database functions"]
+    E["QMT / xtdata"] --> F["MarketDataService"]
+    F --> C
+    D --> B
+    B --> G["Strategy"]
+    G --> H["Rust BacktestEngine"]
+    H --> I["Orders and fills"]
+    H --> J["Portfolio state"]
+    H --> K["Stats"]
+    K --> L["Analyzers"]
+    K --> M["FastAPI"]
+    M --> N["Streamlit"]
+```
+
+## Main Components
+
+| Component | Responsibility |
+|---|---|
+| `python/pyrust_bt/api.py` | Thin Python wrapper around the Rust engine |
+| `python/pyrust_bt/strategy.py` | Base strategy lifecycle |
+| `python/pyrust_bt/data.py` | CSV to bar dictionaries |
+| `python/pyrust_bt/analyzers.py` | Drawdowns, round trips, metrics, factor backtest |
+| `python/pyrust_bt/optimize.py` | Grid search |
+| `python/pyrust_bt/market_data/service.py` | DB-first market data service with optional xtdata fallback |
+| `rust/engine_rust/src/lib.rs` | Backtest engine, indicators, factor fast path |
+| `rust/engine_rust/src/database.rs` | DuckDB K-line storage and query functions |
+| `python/server_main.py` | FastAPI run service |
+| `frontend/streamlit_app.py` | Streamlit UI |
+
+## Single-Asset Backtest Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Py as Python API
+    participant Rust as Rust Engine
+    participant Strat as Strategy
+
+    User->>Py: BacktestEngine(cfg).run(strategy, bars)
+    Py->>Rust: pass strategy and bars
+    Rust->>Rust: extract bars into Rust structs
+    Rust->>Strat: on_start(ctx)
+    loop each bar
+        Rust->>Strat: next(bar, ctx)
+        Strat-->>Rust: action or None
+        Rust->>Rust: parse action
+        Rust->>Rust: match order
+        Rust->>Rust: update position and cash
+        Rust->>Strat: on_order / on_trade
+        Rust->>Rust: append equity point
+    end
+    Rust->>Strat: on_stop()
+    Rust-->>Py: result dict
+    Py-->>User: result
+```
+
+## Multi-Asset Backtest Flow
+
+`run_multi()` accepts:
+
+```python
+feeds = {
+    "asset1": bars1,
+    "asset2": bars2,
+}
+```
+
+The Rust engine:
+
+1. Extracts all feed bars.
+2. Builds a combined timeline from bar datetimes.
+3. Updates the latest bar snapshot for each feed.
+4. Builds a portfolio context with cash, equity, positions, and last prices.
+5. Calls `strategy.next_multi(update_slice, ctx)`.
+6. Parses one action or a list of actions.
+7. Updates per-symbol positions and portfolio cash.
+
+## Data Architecture
+
+The simplest path is CSV:
+
+```text
+CSV -> load_csv_to_bars() -> engine.run()
+```
+
+The production-style local path is DuckDB:
+
+```text
+CSV or QMT -> Rust save_klines() -> DuckDB -> Rust get_market_data() -> bars -> engine
+```
+
+`MarketDataService` implements:
+
+```text
+query DuckDB
+  -> detect missing range
+  -> download from xtdata when enabled
+  -> save fresh data to DuckDB
+  -> query DuckDB again
+```
+
+## Performance Design
+
+The engine reduces Python overhead by:
+
+- Extracting bar data before the loop.
+- Preallocating result buffers.
+- Processing bars in configurable batches.
+- Keeping position updates in Rust.
+- Exposing vectorized indicators from Rust.
+
+The strategy is still called from Python at every bar. That is intentional: users keep Python strategy flexibility, while the bookkeeping and matching path stays in Rust.
+
+## Known Boundaries
+
+- The order model is same-bar simplified execution.
+- Pending order lifecycle is not modeled yet.
+- Multi-asset result output is currently portfolio-level, not a full per-symbol ledger.
+- FastAPI run state is in memory.
+- QMT / xtdata support depends on local vendor environment setup.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,74 @@
+# Examples
+
+The examples are designed as a learning path. Run them from the repository root after building the Rust extension.
+
+## First Run
+
+| Example | Command | What you learn |
+|---|---|---|
+| Minimal backtest | `python examples/run_mvp.py` | Load CSV bars, run a strategy, inspect stats |
+| Analysis demo | `python examples/run_analyzers.py` | Drawdowns, round trips, reports |
+| Performance test | `python examples/run_performance_test.py` | Batch size and throughput behavior |
+
+## Strategy Research
+
+| Example | Command | What you learn |
+|---|---|---|
+| Grid search | `python examples/run_grid_search.py` | Parameter combinations and score sorting |
+| Multi-asset SMA | `python examples/run_multi_assets.py` | `run_multi()` with multiple feeds |
+| Portfolio backtest | `python examples/run_portfolio_backtest.py` | Portfolio-level workflow and reporting |
+
+## Market Data
+
+| Example | Command | What you learn |
+|---|---|---|
+| CSV to DuckDB | `python examples/import_csv_to_db.py --help` | High-performance local data import |
+| Multi-asset rebalance with data service | `python examples/run_multi_asset_rebalance_strategy.py` | DuckDB-first data, optional QMT / xtdata fallback |
+
+## Factor Research
+
+| Example | Command | What you learn |
+|---|---|---|
+| Cross-sectional momentum sample | `python examples/run_cs_momentum_sample.py` | Build factor data and run multi-factor analysis |
+| Quantile portfolios | `python examples/run_cs_quantile_portfolios.py` | Convert factor ranks into portfolio simulations |
+
+## Recommended Order
+
+1. `python examples/run_mvp.py`
+2. `python examples/run_analyzers.py`
+3. `python examples/run_grid_search.py`
+4. `python examples/run_multi_assets.py`
+5. `python examples/run_performance_test.py`
+
+Then choose either:
+
+- Market data workflow: `examples/import_csv_to_db.py` and `examples/run_multi_asset_rebalance_strategy.py`
+- Factor workflow: `examples/run_cs_momentum_sample.py` and `examples/run_cs_quantile_portfolios.py`
+
+## Common Example Pattern
+
+Most examples follow the same pattern:
+
+```python
+cfg = BacktestConfig(...)
+engine = BacktestEngine(cfg)
+bars = load_csv_to_bars(...)
+strategy = MyStrategy(...)
+result = engine.run(strategy, bars)
+print(result["stats"])
+```
+
+Multi-asset examples use:
+
+```python
+feeds = {
+    "asset1": bars1,
+    "asset2": bars2,
+}
+
+result = engine.run_multi(strategy, feeds)
+```
+
+## Output Files
+
+Some examples export CSV or JSON files for inspection. These outputs are generated artifacts and can usually be deleted safely after experimentation.

--- a/docs/factor-analysis.md
+++ b/docs/factor-analysis.md
@@ -1,0 +1,121 @@
+# Factor Analysis
+
+pyrust-bt includes two factor research paths:
+
+1. Simple factor backtest on bar lists.
+2. Cross-sectional factor and quantile portfolio analysis with pandas.
+
+## Simple Factor Backtest
+
+Use `factor_backtest()` when each bar already contains a factor value.
+
+```python
+from pyrust_bt.analyzers import factor_backtest
+
+result = factor_backtest(
+    bars,
+    factor_key="momentum_20",
+    quantiles=5,
+    forward=5,
+)
+
+print(result["ic"])
+print(result["mean_returns"])
+```
+
+The result includes:
+
+| Field | Meaning |
+|---|---|
+| `quantiles` | Quantile labels |
+| `mean_returns` | Mean forward return by quantile |
+| `ic` | Pearson correlation between factor and forward returns |
+| `monotonicity` | Directional consistency across quantile returns |
+| `q_bounds` | Quantile boundaries |
+| `factor_stats` | Mean, standard deviation, min, max |
+
+For larger datasets, the Python function automatically tries the Rust fast path `factor_backtest_fast`.
+
+## Multi-Factor Analyzer
+
+`MultiFactorAnalyzer` evaluates multiple factor columns and builds a ranking.
+
+```python
+from pyrust_bt.multi_factor_analyzer import MultiFactorAnalyzer
+
+analyzer = MultiFactorAnalyzer(
+    bars,
+    window_size=60,
+    nan_policy="drop",
+)
+
+report = analyzer.analyze_all_factors()
+analyzer.export_report(report, output_dir="factor_reports")
+```
+
+It can compute:
+
+- IC and ICIR
+- IC win rate
+- Rank IC
+- Quantile mean returns
+- Monotonicity
+- Turnover
+- Factor decay
+- Stability score
+- Factor correlation matrix
+- Factor ranking
+
+## Cross-Sectional Quantile Backtester
+
+Use `CrossSectionFactorBacktester` when your input is a pandas DataFrame with one row per `(datetime, symbol)`.
+
+Required columns:
+
+```text
+datetime, symbol, factor, ret_next
+```
+
+Example:
+
+```python
+from pyrust_bt.cs_factor_backtester import BacktestConfigCS, CrossSectionFactorBacktester
+
+cfg = BacktestConfigCS(
+    factor_col="factor",
+    ret_next_col="ret_next",
+    datetime_col="datetime",
+    symbol_col="symbol",
+    quantiles=5,
+    winsorize=(0.01, 0.99),
+    standardize=True,
+)
+
+bt = CrossSectionFactorBacktester(df, cfg)
+result = bt.run(compute_long_short=True)
+bt.export(result, out_dir="examples/results/cs_factor")
+```
+
+Outputs include:
+
+- Return series by quantile.
+- Equity series by quantile.
+- Statistics by quantile.
+- Optional long-short return and equity.
+- Turnover by quantile.
+
+## When to Use Which Tool
+
+| Tool | Best for |
+|---|---|
+| `factor_backtest()` | Quick single-factor checks on one bar list |
+| `MultiFactorAnalyzer` | Ranking many factor columns and exporting reports |
+| `CrossSectionFactorBacktester` | Daily cross-sectional factor research and quantile portfolios |
+| `engine.run_multi()` | Trading simulation after factor signals have been converted to orders |
+
+## Important Assumptions
+
+- `ret_next` should be prepared before cross-sectional backtesting.
+- Standardization and winsorization are done within each date when configured.
+- Quantile portfolio returns are equal-weighted by default.
+- The cross-sectional backtester does not model order fills, slippage, or commission. Use `run_multi()` for trading simulation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,137 @@
+# Getting Started
+
+This guide builds the Rust extension and runs the first backtest from the repository root.
+
+## Requirements
+
+- Python 3.8 or newer
+- Rust installed through `rustup`
+- `maturin`
+- A shell that can run PowerShell commands on Windows
+
+Install `maturin`:
+
+```powershell
+pip install maturin
+```
+
+Verify Rust:
+
+```powershell
+rustc --version
+cargo --version
+```
+
+## Build the Rust Extension
+
+The Python package imports `engine_rust`, which is produced by the Rust crate under `rust/engine_rust`.
+
+```powershell
+cd rust/engine_rust
+maturin develop --release
+cd ../..
+```
+
+Use the debug build only when you are actively debugging Rust:
+
+```powershell
+cd rust/engine_rust
+maturin develop
+cd ../..
+```
+
+## Run the Minimal Example
+
+```powershell
+python examples/run_mvp.py
+```
+
+This example:
+
+- Loads CSV bars from `examples/data/sh600000_min.csv`.
+- Creates a `BacktestConfig`.
+- Runs a simple SMA strategy.
+- Prints account state, return metrics, risk metrics, and trade statistics.
+
+## Minimal Python Script
+
+If you run this as your own script from the repository root, make sure Python can see the local package:
+
+```powershell
+$env:PYTHONPATH="python"
+```
+
+```python
+from pyrust_bt.api import BacktestConfig, BacktestEngine
+from pyrust_bt.data import load_csv_to_bars
+from pyrust_bt.strategy import Strategy
+
+
+class MyStrategy(Strategy):
+    def next(self, bar):
+        if bar["close"] > 100:
+            return {"action": "BUY", "type": "market", "size": 1.0}
+        return None
+
+
+cfg = BacktestConfig(
+    start="2020-01-01",
+    end="2025-12-31",
+    cash=100000.0,
+    commission_rate=0.0005,
+    slippage_bps=2.0,
+    batch_size=1000,
+)
+
+bars = load_csv_to_bars("examples/data/sample.csv", symbol="SAMPLE")
+result = BacktestEngine(cfg).run(MyStrategy(), bars)
+
+print(result["cash"])
+print(result["equity"])
+print(result["stats"])
+```
+
+## Input Data Format
+
+The basic CSV loader expects these columns:
+
+```text
+datetime,open,high,low,close,volume
+```
+
+The loader returns a list of dictionaries:
+
+```python
+{
+    "datetime": "2024-01-02 09:30:00",
+    "open": 100.0,
+    "high": 101.0,
+    "low": 99.5,
+    "close": 100.5,
+    "volume": 100000.0,
+    "symbol": "SAMPLE",
+}
+```
+
+## Result Shape
+
+`engine.run()` returns a dictionary with:
+
+| Key | Meaning |
+|---|---|
+| `cash` | Ending cash balance |
+| `position` | Ending single-asset position |
+| `avg_cost` | Average cost of the open position |
+| `equity` | Ending equity |
+| `realized_pnl` | Realized PnL from closed quantity |
+| `equity_curve` | List of `{datetime, equity}` rows |
+| `trades` | Filled trades |
+| `stats` | Summary metrics |
+
+Common statistics include `total_return`, `annualized_return`, `volatility`, `sharpe`, `calmar`, `max_drawdown`, `max_dd_duration`, `total_trades`, and `win_rate`.
+
+## Next Steps
+
+- Read [Strategy Guide](strategy-guide.md) to write real strategies.
+- Read [Examples](examples.md) to pick a runnable workflow.
+- Read [Troubleshooting](troubleshooting.md) if the Rust extension cannot be imported.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+# pyrust-bt Documentation
+
+This documentation is organized as a learning path first and a reference second. Start with the quick guides, then use the topic pages when you need a specific part of the framework.
+
+## Start Here
+
+1. [Getting Started](getting-started.md): install dependencies, build the Rust extension, and run the first backtest.
+2. [Strategy Guide](strategy-guide.md): implement `Strategy`, return actions, and use callbacks.
+3. [Examples](examples.md): choose the right runnable example for your task.
+4. [Architecture](architecture.md): understand how Python, Rust, DuckDB, FastAPI, and Streamlit fit together.
+
+## Topic Guides
+
+| Guide | What it covers |
+|---|---|
+| [Market Data](market-data.md) | CSV, DuckDB, QMT / xtdata fallback, and local data persistence |
+| [Factor Analysis](factor-analysis.md) | Single-factor tests, multi-factor reports, IC, rank IC, and quantile portfolios |
+| [Troubleshooting](troubleshooting.md) | Import errors, build errors, data issues, and runtime checks |
+
+## Recommended Reading Order
+
+```mermaid
+flowchart TD
+    A["Getting Started"] --> B["Strategy Guide"]
+    B --> C["Examples"]
+    C --> D["Architecture"]
+    C --> E["Market Data"]
+    C --> F["Factor Analysis"]
+    D --> G["Troubleshooting"]
+    E --> G
+    F --> G
+```
+
+## Core Entry Points
+
+| Component | File |
+|---|---|
+| Python engine wrapper | `python/pyrust_bt/api.py` |
+| Strategy base class | `python/pyrust_bt/strategy.py` |
+| CSV loader | `python/pyrust_bt/data.py` |
+| Analyzers | `python/pyrust_bt/analyzers.py` |
+| Grid search | `python/pyrust_bt/optimize.py` |
+| Market data service | `python/pyrust_bt/market_data/service.py` |
+| Rust engine | `rust/engine_rust/src/lib.rs` |
+| Rust DuckDB functions | `rust/engine_rust/src/database.rs` |
+| FastAPI service | `python/server_main.py` |
+| Streamlit app | `frontend/streamlit_app.py` |

--- a/docs/market-data.md
+++ b/docs/market-data.md
@@ -1,0 +1,125 @@
+# Market Data
+
+pyrust-bt supports three practical data paths:
+
+1. CSV for quick experiments.
+2. DuckDB for local historical data.
+3. DuckDB plus QMT / xtdata fallback for missing ranges.
+
+## CSV
+
+The basic loader is `load_csv_to_bars()`:
+
+```python
+from pyrust_bt.data import load_csv_to_bars
+
+bars = load_csv_to_bars("examples/data/sample.csv", symbol="SAMPLE")
+```
+
+Expected columns:
+
+```text
+datetime,open,high,low,close,volume
+```
+
+Use CSV when the dataset is small, portable, or part of an example.
+
+## DuckDB Local Store
+
+The Rust extension exposes DuckDB functions:
+
+- `get_market_data`
+- `save_klines`
+- `save_klines_from_csv`
+- `resample_klines`
+
+Use `examples/import_csv_to_db.py` to import a CSV:
+
+```powershell
+python examples/import_csv_to_db.py data/sh600000_min.csv --symbol 600000.SH --period 1m --db data/backtest.db
+```
+
+Use `--no-direct-csv` when you want Python to parse the CSV first before writing through Rust.
+
+DuckDB tables are created per period, such as:
+
+```text
+klines_1m
+klines_1d
+```
+
+Each table stores:
+
+```text
+symbol, datetime, open, high, low, close, volume
+```
+
+## DB-First Service
+
+The high-level service is `MarketDataService`.
+
+```python
+from pyrust_bt.market_data import DataRequest, MarketDataConfig, MarketDataService
+
+config = MarketDataConfig(
+    db_path="data/backtest.db",
+    xtdata_enabled=False,
+)
+
+service = MarketDataService(config)
+
+request = DataRequest(
+    symbols=["513500.SH"],
+    period="1d",
+    start_time="2022-01-01",
+    end_time="2025-12-31",
+)
+
+bars = service.fetch_bars(request, symbol="513500.SH")
+```
+
+When `xtdata_enabled=False`, missing data raises an error instead of downloading.
+
+## QMT / xtdata Fallback
+
+When QMT support is enabled, the service flow is:
+
+```text
+read DuckDB
+  -> detect missing ranges
+  -> download missing data from xtdata
+  -> save to DuckDB
+  -> read DuckDB again
+```
+
+Typical configuration:
+
+```python
+config = MarketDataConfig(
+    db_path="data/backtest.db",
+    xtdata_enabled=True,
+    xtdata_data_dir=r"D:\path\to\userdata_mini",
+)
+```
+
+Environment checklist:
+
+- The QMT / MiniQmt client is installed and configured.
+- The `xtquant` Python package is importable.
+- `XTDATA_DIR` points to the correct `userdata_mini` directory when used by examples.
+- The requested symbol format matches the data vendor, such as `513500.SH` or `159941.SZ`.
+
+## Choosing a Data Path
+
+| Use case | Recommended path |
+|---|---|
+| First demo | CSV |
+| Small experiment | CSV or DuckDB |
+| Repeated research | DuckDB |
+| Multi-asset local research | DuckDB |
+| China A-share or ETF workflow with QMT | DuckDB + xtdata fallback |
+| Large production pipeline | Extend the data layer with Parquet / Arrow or a dedicated feed |
+
+## Data Quality Notes
+
+The service sanitizes data frames by sorting timestamps and removing duplicate index entries. It does not currently handle trading calendars, symbol suspensions, corporate actions, or timezone normalization as full first-class concepts. Add those checks in the data preparation layer when your research depends on them.

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -1,0 +1,193 @@
+# Strategy Guide
+
+Strategies are Python classes that inherit from `pyrust_bt.strategy.Strategy`. The Rust engine calls them while it advances through bars.
+
+## Lifecycle
+
+```text
+on_start(ctx)
+  -> next(bar) or next(bar, ctx)
+  -> on_order(event)
+  -> on_trade(event)
+  -> on_stop()
+```
+
+For multi-asset backtests, the engine prefers:
+
+```python
+next_multi(update_slice, ctx)
+```
+
+and falls back to `next()` when `next_multi()` is not available.
+
+## Single-Asset Strategy
+
+```python
+from pyrust_bt.strategy import Strategy
+
+
+class SMAStrategy(Strategy):
+    def __init__(self, window=5, size=1.0):
+        self.window = window
+        self.size = size
+        self.closes = []
+
+    def next(self, bar):
+        close = float(bar["close"])
+        self.closes.append(close)
+
+        if len(self.closes) < self.window:
+            return None
+
+        sma = sum(self.closes[-self.window:]) / self.window
+
+        if close > sma:
+            return {"action": "BUY", "type": "market", "size": self.size}
+        if close < sma:
+            return {"action": "SELL", "type": "market", "size": self.size}
+        return None
+```
+
+## Context-Aware Strategy
+
+The Rust engine first tries `next(bar, ctx)`. If that call fails because your strategy only accepts one argument, it falls back to `next(bar)`.
+
+```python
+class CashAwareStrategy(Strategy):
+    def next(self, bar, ctx):
+        if ctx.cash <= 0:
+            return None
+
+        if bar["close"] > bar["open"]:
+            return {"action": "BUY", "type": "market", "size": 1.0}
+        return None
+```
+
+Single-asset `ctx` exposes:
+
+| Field | Meaning |
+|---|---|
+| `position` | Current position |
+| `avg_cost` | Average cost |
+| `cash` | Current cash |
+| `equity` | Current equity |
+| `bar_index` | Zero-based bar index |
+
+## Action Format
+
+String actions are shorthand market orders:
+
+```python
+return "BUY"
+return "SELL"
+```
+
+Dictionary actions are explicit orders:
+
+```python
+return {
+    "action": "BUY",
+    "type": "market",
+    "size": 10.0,
+}
+```
+
+```python
+return {
+    "action": "SELL",
+    "type": "limit",
+    "size": 10.0,
+    "price": 105.0,
+}
+```
+
+Supported fields:
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `action` | yes | `BUY` or `SELL` |
+| `type` | no | `market` or `limit`, defaults to `market` |
+| `size` | no | Order size, defaults to `1.0` |
+| `price` | for limit | Limit price |
+| `symbol` | multi-asset | Target symbol |
+
+## Order and Trade Callbacks
+
+Use callbacks for logging, diagnostics, or external state.
+
+```python
+class LoggingStrategy(Strategy):
+    def on_order(self, event):
+        print("order:", event)
+
+    def on_trade(self, event):
+        print("trade:", event)
+```
+
+Order events include submission and fill notifications. Trade events include `order_id`, `side`, `price`, `size`, and `symbol` when available.
+
+## Multi-Asset Strategy
+
+`run_multi()` receives feeds as a dictionary:
+
+```python
+feeds = {
+    "SPY": spy_bars,
+    "QQQ": qqq_bars,
+}
+```
+
+Implement `next_multi()` to trade multiple symbols at a shared timeline step:
+
+```python
+class EqualWeightStrategy(Strategy):
+    def __init__(self, symbols):
+        self.symbols = symbols
+        self.rebalanced = False
+
+    def next_multi(self, update_slice, ctx):
+        if self.rebalanced:
+            return None
+
+        equity = float(ctx["equity"])
+        target_value = equity / len(self.symbols)
+        actions = []
+
+        for symbol in self.symbols:
+            bar = update_slice.get(symbol)
+            if not bar:
+                continue
+            price = float(bar["close"])
+            size = target_value / price
+            actions.append({
+                "action": "BUY",
+                "type": "market",
+                "size": size,
+                "symbol": symbol,
+            })
+
+        self.rebalanced = True
+        return actions
+```
+
+Multi-asset `ctx` includes:
+
+| Field | Meaning |
+|---|---|
+| `positions` | Per-symbol position and average cost |
+| `cash` | Portfolio cash |
+| `equity` | Portfolio equity |
+| `bar_index` | Timeline step |
+| `last_prices` | Latest known price by symbol |
+
+## Matching Model
+
+The current matching model is simple by design:
+
+- Market orders fill at the current bar close.
+- Limit buys fill when current price is less than or equal to the limit.
+- Limit sells fill when current price is greater than or equal to the limit.
+- Slippage is applied by side.
+- Commission is applied to executed notional.
+
+This is suitable for fast research and strategy prototyping. It is not a market microstructure simulator.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,144 @@
+# Troubleshooting
+
+This page lists common setup and runtime issues.
+
+## `engine_rust extension is not built`
+
+Symptom:
+
+```text
+RuntimeError: engine_rust extension is not built
+```
+
+Fix:
+
+```powershell
+cd rust/engine_rust
+maturin develop --release
+cd ../..
+```
+
+Then verify:
+
+```powershell
+python -c "import engine_rust; print(engine_rust)"
+```
+
+## Python Cannot Import `pyrust_bt`
+
+When running from the repository root, examples add `python/` to `sys.path`. In your own scripts, use one of these approaches:
+
+```powershell
+$env:PYTHONPATH="python"
+python your_script.py
+```
+
+or install the package layout in your environment if you add packaging metadata later.
+
+## Rust Build Fails
+
+Try:
+
+```powershell
+rustup update
+cd rust/engine_rust
+cargo clean
+maturin develop --release
+```
+
+Also check that your Python version is compatible with the PyO3 `abi3-py38` configuration.
+
+## `maturin` Is Missing
+
+```powershell
+pip install maturin
+```
+
+If you use a virtual environment, activate it before running `maturin develop`.
+
+## CSV Loader Errors
+
+The default loader expects:
+
+```text
+datetime,open,high,low,close,volume
+```
+
+Check:
+
+- The file path exists.
+- The header names match exactly.
+- Numeric columns can be parsed as floats.
+- The file is encoded as UTF-8.
+
+## Empty Backtest Results
+
+Check:
+
+- `bars` is not empty.
+- `bar["close"]` is present and non-zero.
+- Your strategy returns an action.
+- `size` is greater than zero.
+- The symbol in a multi-asset action exists in the feed or latest price map.
+
+## Limit Orders Do Not Fill
+
+The current limit model is same-bar simplified execution:
+
+- Buy limit fills if current price is less than or equal to the limit.
+- Sell limit fills if current price is greater than or equal to the limit.
+
+There is no persistent pending order book yet.
+
+## QMT / xtdata Errors
+
+Check:
+
+- `xtquant` is importable in the active Python environment.
+- QMT / MiniQmt has downloaded the requested market data.
+- `XTDATA_DIR` points to the correct `userdata_mini` directory.
+- Symbol suffixes match vendor conventions, for example `.SH` or `.SZ`.
+- `MarketDataConfig.xtdata_enabled` is set correctly.
+
+## Streamlit Cannot Reach API
+
+Start FastAPI:
+
+```powershell
+python -m uvicorn python.server_main:app --reload
+```
+
+Set the frontend endpoint:
+
+```powershell
+set PYRUST_BT_API=http://127.0.0.1:8000
+streamlit run frontend/streamlit_app.py
+```
+
+Open the API in a browser:
+
+```text
+http://127.0.0.1:8000/runs
+```
+
+## Performance Is Lower Than Expected
+
+Try:
+
+- Use `maturin develop --release`, not a debug build.
+- Increase `batch_size` to `1000` or `5000`.
+- Avoid printing from `next()` on every bar.
+- Keep expensive pandas operations outside the strategy loop.
+- Use Rust vectorized indicators for large arrays.
+
+## Before Reporting an Issue
+
+Include:
+
+- Operating system.
+- Python version.
+- Rust version.
+- `maturin` version.
+- Exact command that failed.
+- Full error message.
+- Whether `python -c "import engine_rust"` works.

--- a/images/pyrust-bt-logo.svg
+++ b/images/pyrust-bt-logo.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="240" viewBox="0 0 640 240">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10192E"/>
+      <stop offset="100%" stop-color="#1F3B38"/>
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#48C9B0"/>
+      <stop offset="100%" stop-color="#1ABC9C"/>
+    </linearGradient>
+    <linearGradient id="duotoneSnake" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3679F4"/>
+      <stop offset="100%" stop-color="#F4A136"/>
+    </linearGradient>
+    <linearGradient id="duotoneGear" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#F4A136"/>
+      <stop offset="100%" stop-color="#E3563A"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+  <rect width="640" height="240" rx="24" fill="url(#bgGradient)"/>
+  <g filter="url(#shadow)">
+    <circle cx="120" cy="120" r="84" fill="#0A1429" opacity="0.85"/>
+    <path d="M120 48c-28 0-52 18-58 44-2 10 4 18 14 18h30c10 0 18 8 18 18s-8 18-18 18H92c-8 0-12 10-6 16 12 12 30 20 50 20 36 0 64-28 64-64S156 48 120 48z" fill="url(#duotoneSnake)"/>
+    <path d="M132 110a12 12 0 1 1-24 0 12 12 0 0 1 24 0z" fill="#0A1429" opacity="0.85"/>
+    <g transform="translate(220 46)">
+      <path d="M96 0l15 8 17-6 11 13h18l5 17 16 7v18l16 9-6 17 11 14-11 14 6 17-16 9v18l-16 7-5 17h-18l-11 13-17-6-15 8-15-8-17 6-11-13h-18l-5-17-16-7v-18l-16-9 6-17-11-14 11-14-6-17 16-9V39l16-7 5-17h18l11-13 17 6z" fill="#191929"/>
+      <circle cx="96" cy="96" r="64" fill="url(#duotoneGear)"/>
+      <path d="M96 56c-22 0-40 18-40 40s18 40 40 40c4 0 8-3 8-8v-24h24c5 0 8-4 8-8 0-22-18-40-40-40z" fill="#102432"/>
+      <circle cx="96" cy="96" r="18" fill="url(#accentGradient)"/>
+    </g>
+  </g>
+  <g transform="translate(220 176)">
+    <text font-family="Segoe UI, sans-serif" font-size="56" font-weight="600" fill="#F5F7FA" letter-spacing="8">PYRUST</text>
+    <text x="353" font-family="Segoe UI, sans-serif" font-size="56" font-weight="600" fill="url(#accentGradient)" letter-spacing="12">BT</text>
+  </g>
+  <text x="220" y="212" font-family="Segoe UI, sans-serif" font-size="24" fill="#8AD8C7" letter-spacing="4">QUANT BACKTESTING ENGINE</text>
+</svg>

--- a/rust/engine_rust/src/lib.rs
+++ b/rust/engine_rust/src/lib.rs
@@ -34,14 +34,21 @@ pub struct BacktestConfig {
     #[pyo3(get)]
     pub slippage_bps: f64,
     #[pyo3(get)]
-    pub batch_size: usize,  // 新增：批处理大小
+    pub batch_size: usize, // 新增：批处理大小
 }
 
 #[pymethods]
 impl BacktestConfig {
     #[new]
     #[pyo3(signature = (start, end, cash, commission_rate=0.0, slippage_bps=0.0, batch_size=1000))]
-    fn new(start: String, end: String, cash: f64, commission_rate: f64, slippage_bps: f64, batch_size: usize) -> Self {
+    fn new(
+        start: String,
+        end: String,
+        cash: f64,
+        commission_rate: f64,
+        slippage_bps: f64,
+        batch_size: usize,
+    ) -> Self {
         Self {
             start,
             end,
@@ -76,6 +83,17 @@ struct Order {
     symbol: String,
 }
 
+#[derive(Clone, Debug)]
+struct TradeRecord {
+    order_id: u64,
+    symbol: String,
+    side: String,
+    price: f64,
+    size: f64,
+    datetime: Option<String>,
+    commission: f64,
+}
+
 #[derive(Default, Clone, Debug)]
 struct PositionState {
     position: f64,
@@ -100,21 +118,20 @@ pub fn vectorized_sma(prices: &[f64], window: usize) -> Vec<Option<f64>> {
     if prices.is_empty() || window == 0 {
         return vec![None; prices.len()];
     }
-    
+
     let mut result = Vec::with_capacity(prices.len());
     let mut sum = 0.0;
-    
+
     for i in 0..prices.len() {
-        if i < window {
-            sum += prices[i];
-            result.push(None);
-        } else if i == window {
-            sum += prices[i];
+        sum += prices[i];
+        if i >= window {
+            sum -= prices[i - window];
+        }
+
+        if i + 1 >= window {
             result.push(Some(sum / window as f64));
         } else {
-            // 滑动窗口：减去最旧的，加上最新的
-            sum = sum - prices[i - window] + prices[i];
-            result.push(Some(sum / window as f64));
+            result.push(None);
         }
     }
     result
@@ -124,16 +141,16 @@ pub fn vectorized_rsi(prices: &[f64], window: usize) -> Vec<Option<f64>> {
     if prices.len() < 2 || window == 0 {
         return vec![None; prices.len()];
     }
-    
+
     let mut result = Vec::with_capacity(prices.len());
     result.push(None); // 第一个价格没有变化
-    
+
     let mut gains = Vec::with_capacity(prices.len());
     let mut losses = Vec::with_capacity(prices.len());
-    
+
     // 计算价格变化
     for i in 1..prices.len() {
-        let change = prices[i] - prices[i-1];
+        let change = prices[i] - prices[i - 1];
         if change > 0.0 {
             gains.push(change);
             losses.push(0.0);
@@ -142,11 +159,11 @@ pub fn vectorized_rsi(prices: &[f64], window: usize) -> Vec<Option<f64>> {
             losses.push(-change);
         }
     }
-    
+
     // 计算RSI
     let mut avg_gain = 0.0;
     let mut avg_loss = 0.0;
-    
+
     for i in 0..gains.len() {
         if i < window - 1 {
             result.push(None);
@@ -154,7 +171,7 @@ pub fn vectorized_rsi(prices: &[f64], window: usize) -> Vec<Option<f64>> {
             // 初始平均
             avg_gain = gains[0..window].iter().sum::<f64>() / window as f64;
             avg_loss = losses[0..window].iter().sum::<f64>() / window as f64;
-            
+
             let rsi = if avg_loss == 0.0 {
                 100.0
             } else {
@@ -165,7 +182,7 @@ pub fn vectorized_rsi(prices: &[f64], window: usize) -> Vec<Option<f64>> {
             // Wilder的平滑方法
             avg_gain = ((avg_gain * (window - 1) as f64) + gains[i]) / window as f64;
             avg_loss = ((avg_loss * (window - 1) as f64) + losses[i]) / window as f64;
-            
+
             let rsi = if avg_loss == 0.0 {
                 100.0
             } else {
@@ -174,7 +191,7 @@ pub fn vectorized_rsi(prices: &[f64], window: usize) -> Vec<Option<f64>> {
             result.push(Some(rsi));
         }
     }
-    
+
     result
 }
 
@@ -191,22 +208,39 @@ fn compute_rsi(prices: Vec<f64>, window: usize) -> Vec<Option<f64>> {
 // 批量提取bar数据，减少Python调用
 fn extract_bars_data(bars: &PyList) -> PyResult<Vec<BarData>> {
     let mut bars_data = Vec::with_capacity(bars.len());
-    
+
     for item in bars.iter() {
         let bar: &PyDict = item.downcast()?;
-        
+
         let datetime = match bar.get_item("datetime")? {
             Some(v) => v.extract::<String>().ok(),
             None => None,
         };
-        
-        let open = bar.get_item("open")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(0.0);
-        let high = bar.get_item("high")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(0.0);
-        let low = bar.get_item("low")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(0.0);
-        let close = bar.get_item("close")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(0.0);
-        let volume = bar.get_item("volume")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(0.0);
-        let symbol = bar.get_item("symbol")?.and_then(|v| v.extract::<String>().ok());
-        
+
+        let open = bar
+            .get_item("open")?
+            .and_then(|v| v.extract::<f64>().ok())
+            .unwrap_or(0.0);
+        let high = bar
+            .get_item("high")?
+            .and_then(|v| v.extract::<f64>().ok())
+            .unwrap_or(0.0);
+        let low = bar
+            .get_item("low")?
+            .and_then(|v| v.extract::<f64>().ok())
+            .unwrap_or(0.0);
+        let close = bar
+            .get_item("close")?
+            .and_then(|v| v.extract::<f64>().ok())
+            .unwrap_or(0.0);
+        let volume = bar
+            .get_item("volume")?
+            .and_then(|v| v.extract::<f64>().ok())
+            .unwrap_or(0.0);
+        let symbol = bar
+            .get_item("symbol")?
+            .and_then(|v| v.extract::<String>().ok());
+
         bars_data.push(BarData {
             datetime,
             open,
@@ -217,7 +251,7 @@ fn extract_bars_data(bars: &PyList) -> PyResult<Vec<BarData>> {
             symbol,
         });
     }
-    
+
     Ok(bars_data)
 }
 
@@ -249,36 +283,45 @@ impl BacktestEngine {
     }
 
     /// 高性能回测循环：预提取数据、批量处理、减少Python调用
-    fn run<'py>(&self, py: Python<'py>, strategy: PyObject, data: &'py PyAny) -> PyResult<PyObject> {
+    fn run<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: PyObject,
+        data: &'py PyAny,
+    ) -> PyResult<PyObject> {
         let bars: &PyList = data.downcast()?;
         let n_bars = bars.len();
 
         // 预提取所有bar数据到Rust结构中
         let bars_data = extract_bars_data(bars)?;
-        
+
         // 初始上下文（无价格时以现金估算净值）
-        let init_ctx = Py::new(py, EngineContext {
-            position: 0.0,
-            avg_cost: 0.0,
-            cash: self.cfg.cash,
-            equity: self.cfg.cash,
-            bar_index: 0,
-        })?;
+        let init_ctx = Py::new(
+            py,
+            EngineContext {
+                position: 0.0,
+                avg_cost: 0.0,
+                cash: self.cfg.cash,
+                equity: self.cfg.cash,
+                bar_index: 0,
+            },
+        )?;
         let _ = strategy.call_method1(py, "on_start", (init_ctx.as_ref(py),));
+        let next_accepts_ctx = self.method_accepts_ctx(py, &strategy, "next")?;
 
         let mut pos = PositionState::new(self.cfg.cash);
         let mut order_seq: u64 = 1;
 
         // 预分配容量
         let mut equity_curve: Vec<(Option<String>, f64)> = Vec::with_capacity(n_bars);
-        let mut trades: Vec<(u64, String, f64, f64)> = Vec::with_capacity(n_bars / 100);
+        let mut trades: Vec<TradeRecord> = Vec::with_capacity(n_bars / 100);
 
         // 批量处理策略调用，减少Python GIL争用
-        let batch_size = self.cfg.batch_size.min(n_bars);
-        
+        let batch_size = self.cfg.batch_size.max(1).min(n_bars.max(1));
+
         for chunk_start in (0..n_bars).step_by(batch_size) {
             let chunk_end = (chunk_start + batch_size).min(n_bars);
-            
+
             // 处理当前批次
             for i in chunk_start..chunk_end {
                 let bar_data = &bars_data[i];
@@ -295,51 +338,93 @@ impl BacktestEngine {
                 bar_dict.set_item("close", bar_data.close)?;
                 bar_dict.set_item("volume", bar_data.volume)?;
 
-                // 上下文快照传入策略（优先使用 next(bar, ctx)，若失败则回退到 next(bar)）
+                // 上下文快照传入策略
                 let equity_snapshot = pos.cash + pos.position * last_price;
-                let ctx = Py::new(py, EngineContext {
-                    position: pos.position,
-                    avg_cost: pos.avg_cost,
-                    cash: pos.cash,
-                    equity: equity_snapshot,
-                    bar_index: i,
-                })?;
-                let action_obj = match strategy.call_method1(py, "next", (bar_dict.as_any(), ctx.as_ref(py))) {
-                    Ok(obj) => obj,
-                    Err(_) => strategy.call_method1(py, "next", (bar_dict.as_any(),))?,
+                let ctx = Py::new(
+                    py,
+                    EngineContext {
+                        position: pos.position,
+                        avg_cost: pos.avg_cost,
+                        cash: pos.cash,
+                        equity: equity_snapshot,
+                        bar_index: i,
+                    },
+                )?;
+                let action_obj = if next_accepts_ctx {
+                    strategy.call_method1(py, "next", (bar_dict.as_any(), ctx.as_ref(py)))?
+                } else {
+                    strategy.call_method1(py, "next", (bar_dict.as_any(),))?
                 };
 
                 // 快速订单处理
                 let default_symbol = bar_data.symbol.as_deref().unwrap_or("DEFAULT");
-                if let Some(order) = self.parse_action_fast(action_obj.as_ref(py), &mut order_seq, last_price, default_symbol)? {
+                if let Some(order) = self.parse_action_fast(
+                    action_obj.as_ref(py),
+                    &mut order_seq,
+                    last_price,
+                    default_symbol,
+                )? {
                     // 订单提交回调
                     let evt = PyDict::new_bound(py);
                     evt.set_item("event", "submitted")?;
                     evt.set_item("order_id", order.id)?;
-                    evt.set_item("side", match order.side { OrderSide::Buy => "BUY", OrderSide::Sell => "SELL" })?;
-                    evt.set_item("type", match order.otype { OrderType::Market => "market", OrderType::Limit => "limit" })?;
+                    evt.set_item(
+                        "side",
+                        match order.side {
+                            OrderSide::Buy => "BUY",
+                            OrderSide::Sell => "SELL",
+                        },
+                    )?;
+                    evt.set_item(
+                        "type",
+                        match order.otype {
+                            OrderType::Market => "market",
+                            OrderType::Limit => "limit",
+                        },
+                    )?;
                     evt.set_item("size", order.size)?;
                     evt.set_item("symbol", &order.symbol)?;
-                    if let Some(lp) = order.limit_price { evt.set_item("limit_price", lp)?; }
+                    if let Some(lp) = order.limit_price {
+                        evt.set_item("limit_price", lp)?;
+                    }
                     let _ = strategy.call_method1(py, "on_order", (evt.as_any(),));
 
                     if let Some((fill_price, fill_size)) = self.try_match(&order, last_price) {
                         let slip = self.cfg.slippage_bps / 10_000.0;
-                        let sign = match order.side { OrderSide::Buy => 1.0, OrderSide::Sell => -1.0 };
+                        let sign = match order.side {
+                            OrderSide::Buy => 1.0,
+                            OrderSide::Sell => -1.0,
+                        };
                         let exec_price = fill_price * (1.0 + sign * slip);
                         let commission = exec_price * fill_size * self.cfg.commission_rate;
 
                         // 快速持仓更新
                         self.update_position(&mut pos, &order, exec_price, fill_size, commission);
-                        trades.push((order.id, match order.side { OrderSide::Buy => "BUY".to_string(), OrderSide::Sell => "SELL".to_string() }, exec_price, fill_size));
+                        let side = match order.side {
+                            OrderSide::Buy => "BUY".to_string(),
+                            OrderSide::Sell => "SELL".to_string(),
+                        };
+                        trades.push(TradeRecord {
+                            order_id: order.id,
+                            symbol: order.symbol.clone(),
+                            side: side.clone(),
+                            price: exec_price,
+                            size: fill_size,
+                            datetime: bar_data.datetime.clone(),
+                            commission,
+                        });
 
                         // 成交回调
                         let trade_evt = PyDict::new_bound(py);
                         trade_evt.set_item("order_id", order.id)?;
-                        trade_evt.set_item("side", match order.side { OrderSide::Buy => "BUY", OrderSide::Sell => "SELL" })?;
+                        trade_evt.set_item("side", side)?;
                         trade_evt.set_item("price", exec_price)?;
                         trade_evt.set_item("size", fill_size)?;
                         trade_evt.set_item("symbol", &order.symbol)?;
+                        if let Some(dt) = &bar_data.datetime {
+                            trade_evt.set_item("datetime", dt)?;
+                        }
+                        trade_evt.set_item("commission", commission)?;
                         let _ = strategy.call_method1(py, "on_trade", (trade_evt.as_any(),));
 
                         // 订单完成回调
@@ -362,12 +447,32 @@ impl BacktestEngine {
     }
 
     /// 多资产/多周期（按联合时间线）回测（Python 暴露方法）
-    fn run_multi<'py>(&self, py: Python<'py>, strategy: PyObject, feeds: &'py PyAny) -> PyResult<PyObject> {
+    fn run_multi<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: PyObject,
+        feeds: &'py PyAny,
+    ) -> PyResult<PyObject> {
         self._run_multi_impl(py, strategy, feeds)
     }
 }
 
 impl BacktestEngine {
+    fn method_accepts_ctx<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: &PyObject,
+        method_name: &str,
+    ) -> PyResult<bool> {
+        let method = strategy.getattr(py, method_name)?;
+        let inspect = py.import_bound("inspect")?;
+        let signature = inspect.call_method1("signature", (method,))?;
+        let parameters = signature.getattr("parameters")?;
+        let builtins = py.import_bound("builtins")?;
+        let count: usize = builtins.getattr("len")?.call1((parameters,))?.extract()?;
+        Ok(count >= 2)
+    }
+
     // 优化的动作解析，减少类型检查（单资产路径）
     fn parse_action_fast<'py>(
         &self,
@@ -379,27 +484,75 @@ impl BacktestEngine {
         // 快速字符串检查
         if let Ok(s) = action_obj.extract::<Option<String>>() {
             if let Some(act) = s {
-                let side = if act.as_bytes()[0] == b'B' { OrderSide::Buy } else { OrderSide::Sell };
-                let id = *order_seq; *order_seq += 1;
-                return Ok(Some(Order { id, side, otype: OrderType::Market, size: 1.0, limit_price: None, status: "submitted", symbol: default_symbol.to_string() }));
+                let side = if act.as_bytes()[0] == b'B' {
+                    OrderSide::Buy
+                } else {
+                    OrderSide::Sell
+                };
+                let id = *order_seq;
+                *order_seq += 1;
+                return Ok(Some(Order {
+                    id,
+                    side,
+                    otype: OrderType::Market,
+                    size: 1.0,
+                    limit_price: None,
+                    status: "submitted",
+                    symbol: default_symbol.to_string(),
+                }));
             }
         }
 
         // 字典解析
         if let Ok(d) = action_obj.downcast::<PyDict>() {
-            let act = d.get_item("action")?.and_then(|v| v.extract::<String>().ok()).unwrap_or_default();
-            if act.is_empty() { return Ok(None); }
-            
-            let side = if act.as_bytes()[0] == b'B' { OrderSide::Buy } else { OrderSide::Sell };
-            let otype_str = d.get_item("type")?.and_then(|v| v.extract::<String>().ok()).unwrap_or_else(|| "market".into());
-            let otype = if otype_str == "limit" { OrderType::Limit } else { OrderType::Market };
-            let size = d.get_item("size")?.and_then(|v| v.extract::<f64>().ok()).unwrap_or(1.0);
+            let act = d
+                .get_item("action")?
+                .and_then(|v| v.extract::<String>().ok())
+                .unwrap_or_default();
+            if act.is_empty() {
+                return Ok(None);
+            }
+
+            let side = if act.as_bytes()[0] == b'B' {
+                OrderSide::Buy
+            } else {
+                OrderSide::Sell
+            };
+            let otype_str = d
+                .get_item("type")?
+                .and_then(|v| v.extract::<String>().ok())
+                .unwrap_or_else(|| "market".into());
+            let otype = if otype_str == "limit" {
+                OrderType::Limit
+            } else {
+                OrderType::Market
+            };
+            let size = d
+                .get_item("size")?
+                .and_then(|v| v.extract::<f64>().ok())
+                .unwrap_or(1.0);
             let price = d.get_item("price")?.and_then(|v| v.extract::<f64>().ok());
-            let symbol = d.get_item("symbol")?.and_then(|v| v.extract::<String>().ok()).unwrap_or_else(|| default_symbol.to_string());
-            
-            let id = *order_seq; *order_seq += 1;
-            let limit_price = if otype == OrderType::Limit { price.or(Some(last_price)) } else { None };
-            return Ok(Some(Order { id, side, otype, size, limit_price, status: "submitted", symbol }));
+            let symbol = d
+                .get_item("symbol")?
+                .and_then(|v| v.extract::<String>().ok())
+                .unwrap_or_else(|| default_symbol.to_string());
+
+            let id = *order_seq;
+            *order_seq += 1;
+            let limit_price = if otype == OrderType::Limit {
+                price.or(Some(last_price))
+            } else {
+                None
+            };
+            return Ok(Some(Order {
+                id,
+                side,
+                otype,
+                size,
+                limit_price,
+                status: "submitted",
+                symbol,
+            }));
         }
 
         Ok(None)
@@ -421,17 +574,23 @@ impl BacktestEngine {
                 let mut sym = default_symbol.to_string();
                 if let Ok(d) = item.downcast::<PyDict>() {
                     if let Ok(Some(val)) = d.get_item("symbol") {
-                        if let Ok(s) = val.extract::<String>() { sym = s; }
+                        if let Ok(s) = val.extract::<String>() {
+                            sym = s;
+                        }
                     }
                 }
                 let lp = *last_price_map.get(&sym).unwrap_or(&0.0);
-                if let Some(o) = self.parse_action_fast(item, order_seq, lp, &sym)? { out.push(o); }
+                if let Some(o) = self.parse_action_fast(item, order_seq, lp, &sym)? {
+                    out.push(o);
+                }
             }
             return Ok(out);
         }
         // Single
         let lp = *last_price_map.get(default_symbol).unwrap_or(&0.0);
-        if let Some(o) = self.parse_action_fast(action_obj, order_seq, lp, default_symbol)? { return Ok(vec![o]); }
+        if let Some(o) = self.parse_action_fast(action_obj, order_seq, lp, default_symbol)? {
+            return Ok(vec![o]);
+        }
         Ok(Vec::new())
     }
 
@@ -442,15 +601,34 @@ impl BacktestEngine {
             OrderType::Limit => {
                 let lp = order.limit_price.unwrap_or(last_price);
                 match order.side {
-                    OrderSide::Buy => if last_price <= lp { Some((lp, order.size)) } else { None },
-                    OrderSide::Sell => if last_price >= lp { Some((lp, order.size)) } else { None },
+                    OrderSide::Buy => {
+                        if last_price <= lp {
+                            Some((lp, order.size))
+                        } else {
+                            None
+                        }
+                    }
+                    OrderSide::Sell => {
+                        if last_price >= lp {
+                            Some((lp, order.size))
+                        } else {
+                            None
+                        }
+                    }
                 }
             }
         }
     }
 
     #[inline]
-    fn update_position(&self, pos: &mut PositionState, order: &Order, exec_price: f64, fill_size: f64, commission: f64) {
+    fn update_position(
+        &self,
+        pos: &mut PositionState,
+        order: &Order,
+        exec_price: f64,
+        fill_size: f64,
+        commission: f64,
+    ) {
         match order.side {
             OrderSide::Buy => {
                 let cost = exec_price * fill_size + commission;
@@ -474,25 +652,38 @@ impl BacktestEngine {
                     pos.realized_pnl += (exec_price - pos.avg_cost) * closing;
                 }
                 pos.position -= fill_size;
-                if pos.position.abs() < f64::EPSILON { pos.avg_cost = 0.0; }
+                if pos.position.abs() < f64::EPSILON {
+                    pos.avg_cost = 0.0;
+                }
                 pos.cash += proceeds;
             }
         }
     }
 
-    fn build_result<'py>(&self, py: Python<'py>, pos: PositionState, equity_curve: Vec<(Option<String>, f64)>, trades: Vec<(u64, String, f64, f64)>) -> PyResult<PyObject> {
+    fn build_result<'py>(
+        &self,
+        py: Python<'py>,
+        pos: PositionState,
+        equity_curve: Vec<(Option<String>, f64)>,
+        trades: Vec<TradeRecord>,
+    ) -> PyResult<PyObject> {
         let result = PyDict::new_bound(py);
         result.set_item("cash", pos.cash)?;
         result.set_item("position", pos.position)?;
         result.set_item("avg_cost", pos.avg_cost)?;
-        result.set_item("equity", pos.cash + pos.position * equity_curve.last().map_or(0.0, |(_, eq)| *eq))?;
+        let final_equity = equity_curve.last().map_or(pos.cash, |(_, eq)| *eq);
+        result.set_item("equity", final_equity)?;
         result.set_item("realized_pnl", pos.realized_pnl)?;
 
         // 高效构建净值曲线
         let eq_list = PyList::empty_bound(py);
         for (dt, eq) in &equity_curve {
             let row = PyDict::new_bound(py);
-            if let Some(d) = dt { row.set_item("datetime", d)?; } else { row.set_item("datetime", py.None())?; }
+            if let Some(d) = dt {
+                row.set_item("datetime", d)?;
+            } else {
+                row.set_item("datetime", py.None())?;
+            }
             row.set_item("equity", eq)?;
             eq_list.append(row)?;
         }
@@ -500,12 +691,19 @@ impl BacktestEngine {
 
         // 高效构建交易列表
         let tr_list = PyList::empty_bound(py);
-        for (oid, side, price, size) in &trades {
+        for trade in &trades {
             let t = PyDict::new_bound(py);
-            t.set_item("order_id", oid)?;
-            t.set_item("side", side)?;
-            t.set_item("price", price)?;
-            t.set_item("size", size)?;
+            t.set_item("order_id", trade.order_id)?;
+            t.set_item("side", &trade.side)?;
+            t.set_item("price", trade.price)?;
+            t.set_item("size", trade.size)?;
+            t.set_item("symbol", &trade.symbol)?;
+            if let Some(dt) = &trade.datetime {
+                t.set_item("datetime", dt)?;
+            } else {
+                t.set_item("datetime", py.None())?;
+            }
+            t.set_item("commission", trade.commission)?;
             tr_list.append(t)?;
         }
         result.set_item("trades", tr_list)?;
@@ -517,37 +715,58 @@ impl BacktestEngine {
         Ok(result.into())
     }
 
-    fn compute_enhanced_stats<'py>(&self, py: Python<'py>, equity_curve: &[(Option<String>, f64)], trades: &[(u64, String, f64, f64)]) -> PyResult<PyObject> {
+    fn compute_enhanced_stats<'py>(
+        &self,
+        py: Python<'py>,
+        equity_curve: &[(Option<String>, f64)],
+        trades: &[TradeRecord],
+    ) -> PyResult<PyObject> {
         if equity_curve.is_empty() {
             return Ok(PyDict::new_bound(py).into());
         }
-        
+
         let start_equity = equity_curve.first().unwrap().1;
         let end_equity = equity_curve.last().unwrap().1;
-        let total_return = if start_equity != 0.0 { (end_equity / start_equity) - 1.0 } else { 0.0 };
+        let total_return = if start_equity != 0.0 {
+            (end_equity / start_equity) - 1.0
+        } else {
+            0.0
+        };
 
         // 向量化收益率计算
         let mut returns: Vec<f64> = Vec::with_capacity(equity_curve.len().saturating_sub(1));
         for i in 1..equity_curve.len() {
-            let prev = equity_curve[i-1].1;
+            let prev = equity_curve[i - 1].1;
             let curr = equity_curve[i].1;
-            if prev != 0.0 { returns.push((curr / prev) - 1.0); }
+            if prev != 0.0 {
+                returns.push((curr / prev) - 1.0);
+            }
         }
 
-        let mean_return = if returns.is_empty() { 0.0 } else { returns.iter().sum::<f64>() / returns.len() as f64 };
+        let mean_return = if returns.is_empty() {
+            0.0
+        } else {
+            returns.iter().sum::<f64>() / returns.len() as f64
+        };
         let var = if returns.len() > 1 {
             let sum_sq_diff: f64 = returns.iter().map(|r| (r - mean_return).powi(2)).sum();
             sum_sq_diff / (returns.len() - 1) as f64
-        } else { 0.0 };
+        } else {
+            0.0
+        };
         let std = var.sqrt();
-        let sharpe = if std > 0.0 { (mean_return * 252.0_f64.sqrt()) / std } else { 0.0 };
+        let sharpe = if std > 0.0 {
+            (mean_return * 252.0_f64.sqrt()) / std
+        } else {
+            0.0
+        };
 
         // 高效最大回撤计算
         let mut peak = start_equity;
         let mut max_dd: f64 = 0.0;
         let mut dd_duration = 0;
         let mut max_dd_duration = 0;
-        
+
         for &(_, eq) in equity_curve {
             if eq > peak {
                 peak = eq;
@@ -570,21 +789,37 @@ impl BacktestEngine {
             let mut win = 0;
             let mut lose = 0;
             let mut pnl = 0.0;
-            
+
             for i in 0..trades.len() {
-                let (_, side, price, size) = &trades[i];
+                let trade = &trades[i];
                 if i > 0 {
-                    let prev_price = trades[i-1].2;
-                    let profit = if side == "BUY" { (price - prev_price) * size } else { (prev_price - price) * size };
+                    let prev_price = trades[i - 1].price;
+                    let profit = if trade.side == "BUY" {
+                        (trade.price - prev_price) * trade.size
+                    } else {
+                        (prev_price - trade.price) * trade.size
+                    };
                     pnl += profit;
-                    if profit > 0.0 { win += 1; } else if profit < 0.0 { lose += 1; }
+                    if profit > 0.0 {
+                        win += 1;
+                    } else if profit < 0.0 {
+                        lose += 1;
+                    }
                 }
             }
             (win, lose, pnl)
         };
 
-        let win_rate = if total_trades > 0 { winning_trades as f64 / total_trades as f64 } else { 0.0 };
-        let calmar = if max_dd > 0.0 { (mean_return * 252.0) / max_dd } else { 0.0 };
+        let win_rate = if total_trades > 0 {
+            winning_trades as f64 / total_trades as f64
+        } else {
+            0.0
+        };
+        let calmar = if max_dd > 0.0 {
+            (mean_return * 252.0) / max_dd
+        } else {
+            0.0
+        };
 
         let stats = PyDict::new_bound(py);
         stats.set_item("start_equity", start_equity)?;
@@ -601,14 +836,19 @@ impl BacktestEngine {
         stats.set_item("losing_trades", losing_trades)?;
         stats.set_item("win_rate", win_rate)?;
         stats.set_item("total_pnl", total_pnl)?;
-        
+
         Ok(stats.into())
     }
 }
 
 impl BacktestEngine {
     /// 多资产/多周期（按联合时间线）回测。feeds: Dict[str, List[bar]]，bar 至少包含 datetime/close，可选 symbol。
-    fn _run_multi_impl<'py>(&self, py: Python<'py>, strategy: PyObject, feeds: &'py PyAny) -> PyResult<PyObject> {
+    fn _run_multi_impl<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: PyObject,
+        feeds: &'py PyAny,
+    ) -> PyResult<PyObject> {
         let feeds_dict: &PyDict = feeds.downcast()?;
         // 预提取每个 feed 的数据
         let mut feed_ids: Vec<String> = Vec::with_capacity(feeds_dict.len());
@@ -633,8 +873,10 @@ impl BacktestEngine {
 
         // 结果容器
         let mut equity_curve: Vec<(Option<String>, f64)> = Vec::new();
-        let mut trades: Vec<(u64, String, f64, f64)> = Vec::new();
+        let mut trades: Vec<TradeRecord> = Vec::new();
         let mut order_seq: u64 = 1;
+        let has_next_multi = strategy.as_ref(py).hasattr("next_multi")?;
+        let next_accepts_ctx = self.method_accepts_ctx(py, &strategy, "next")?;
 
         // on_start 传入汇总 ctx（Python dict）
         let start_ctx = PyDict::new_bound(py);
@@ -653,12 +895,18 @@ impl BacktestEngine {
                     if let Some(dt) = &feed_bars[f][idxs[f]].datetime {
                         match &min_dt {
                             None => min_dt = Some(dt.clone()),
-                            Some(cur) => { if dt < cur { min_dt = Some(dt.clone()); } }
+                            Some(cur) => {
+                                if dt < cur {
+                                    min_dt = Some(dt.clone());
+                                }
+                            }
                         }
                     }
                 }
             }
-            if min_dt.is_none() { break; }
+            if min_dt.is_none() {
+                break;
+            }
             let cur_dt = min_dt.unwrap();
 
             // 本步更新的 bars 切片
@@ -669,11 +917,17 @@ impl BacktestEngine {
                         let b = &feed_bars[f][idxs[f]];
                         // 更新 last
                         last_snapshot[f] = Some(b.clone());
-                        if let Some(sym) = &b.symbol { last_price_map.insert(sym.clone(), b.close); }
+                        if let Some(sym) = &b.symbol {
+                            last_price_map.insert(sym.clone(), b.close);
+                        }
                         // 构造 bar dict
                         let bd = PyDict::new_bound(py);
-                        if let Some(dt) = &b.datetime { bd.set_item("datetime", dt)?; }
-                        if let Some(sym) = &b.symbol { bd.set_item("symbol", sym)?; }
+                        if let Some(dt) = &b.datetime {
+                            bd.set_item("datetime", dt)?;
+                        }
+                        if let Some(sym) = &b.symbol {
+                            bd.set_item("symbol", sym)?;
+                        }
                         bd.set_item("open", b.open)?;
                         bd.set_item("high", b.high)?;
                         bd.set_item("low", b.low)?;
@@ -697,7 +951,9 @@ impl BacktestEngine {
             // 汇总净值
             let mut equity: f64 = cash;
             for (sym, (p, _)) in positions.iter() {
-                if let Some(lp) = last_price_map.get(sym) { equity += p * lp; }
+                if let Some(lp) = last_price_map.get(sym) {
+                    equity += p * lp;
+                }
             }
             ctx.set_item("positions", pos_dict)?;
             ctx.set_item("cash", cash)?;
@@ -705,46 +961,73 @@ impl BacktestEngine {
             ctx.set_item("bar_index", step)?;
             ctx.set_item("last_prices", {
                 let lp = PyDict::new_bound(py);
-                for (k, v) in last_price_map.iter() { lp.set_item(k, v)?; }
+                for (k, v) in last_price_map.iter() {
+                    lp.set_item(k, v)?;
+                }
                 lp
             })?;
 
-            // 调用策略：next_multi(update_slice, ctx) 优先
-            let action_obj = match strategy.call_method1(py, "next_multi", (update_slice.as_any(), ctx.as_any())) {
-                Ok(obj) => obj,
-                Err(_) => {
-                    // 回退：若存在主 bar，则取第一个 feed 的最新快照
-                    let primary_bar = if let Some(Some(b)) = last_snapshot.get(0) {
-                        let bd = PyDict::new_bound(py);
-                        if let Some(dt) = &b.datetime { bd.set_item("datetime", dt)?; }
-                        if let Some(sym) = &b.symbol { bd.set_item("symbol", sym)?; }
-                        bd.set_item("open", b.open)?;
-                        bd.set_item("high", b.high)?;
-                        bd.set_item("low", b.low)?;
-                        bd.set_item("close", b.close)?;
-                        bd.set_item("volume", b.volume)?;
-                        Some(bd)
-                    } else { None };
-                    if let Some(pb) = primary_bar { strategy.call_method1(py, "next", (pb.as_any(), ctx.as_any()))? } else { py.None() }
+            // 调用策略：仅当 next_multi 不存在时回退到 next，策略内部异常直接传播
+            let action_obj = if has_next_multi {
+                strategy.call_method1(py, "next_multi", (update_slice.as_any(), ctx.as_any()))?
+            } else {
+                let primary_bar = if let Some(Some(b)) = last_snapshot.get(0) {
+                    let bd = PyDict::new_bound(py);
+                    if let Some(dt) = &b.datetime {
+                        bd.set_item("datetime", dt)?;
+                    }
+                    if let Some(sym) = &b.symbol {
+                        bd.set_item("symbol", sym)?;
+                    }
+                    bd.set_item("open", b.open)?;
+                    bd.set_item("high", b.high)?;
+                    bd.set_item("low", b.low)?;
+                    bd.set_item("close", b.close)?;
+                    bd.set_item("volume", b.volume)?;
+                    Some(bd)
+                } else {
+                    None
+                };
+                if let Some(pb) = primary_bar {
+                    if next_accepts_ctx {
+                        strategy.call_method1(py, "next", (pb.as_any(), ctx.as_any()))?
+                    } else {
+                        strategy.call_method1(py, "next", (pb.as_any(),))?
+                    }
+                } else {
+                    py.None()
                 }
             };
 
             // 解析并执行指令（支持 list）
             let default_symbol = if let Some(Some(b)) = last_snapshot.get(0) {
                 b.symbol.clone().unwrap_or_else(|| "DEFAULT".to_string())
-            } else { "DEFAULT".to_string() };
-            let orders = self.parse_actions_any(py, action_obj.as_ref(py), &mut order_seq, &last_price_map, &default_symbol)?;
+            } else {
+                "DEFAULT".to_string()
+            };
+            let orders = self.parse_actions_any(
+                py,
+                action_obj.as_ref(py),
+                &mut order_seq,
+                &last_price_map,
+                &default_symbol,
+            )?;
             for order in orders {
                 // 获取该 symbol 的 last_price
                 let lp = *last_price_map.get(&order.symbol).unwrap_or(&0.0);
                 if let Some((fill_price, fill_size)) = self.try_match(&order, lp) {
                     let slip = self.cfg.slippage_bps / 10_000.0;
-                    let sign = match order.side { OrderSide::Buy => 1.0, OrderSide::Sell => -1.0 };
+                    let sign = match order.side {
+                        OrderSide::Buy => 1.0,
+                        OrderSide::Sell => -1.0,
+                    };
                     let exec_price = fill_price * (1.0 + sign * slip);
                     let commission = exec_price * fill_size * self.cfg.commission_rate;
 
                     // 更新该 symbol 头寸与组合现金
-                    let sp = positions.entry(order.symbol.clone()).or_insert((0.0_f64, 0.0_f64));
+                    let sp = positions
+                        .entry(order.symbol.clone())
+                        .or_insert((0.0_f64, 0.0_f64));
                     match order.side {
                         OrderSide::Buy => {
                             let cost = exec_price * fill_size + commission;
@@ -752,8 +1035,12 @@ impl BacktestEngine {
                             if new_pos.abs() > f64::EPSILON {
                                 sp.1 = if sp.0.abs() > f64::EPSILON {
                                     (sp.1 * sp.0 + exec_price * fill_size) / new_pos
-                                } else { exec_price };
-                            } else { sp.1 = 0.0; }
+                                } else {
+                                    exec_price
+                                };
+                            } else {
+                                sp.1 = 0.0;
+                            }
                             sp.0 = new_pos;
                             cash -= cost;
                         }
@@ -764,19 +1051,35 @@ impl BacktestEngine {
                                 realized_pnl += (exec_price - sp.1) * closing;
                             }
                             sp.0 -= fill_size;
-                            if sp.0.abs() < f64::EPSILON { sp.1 = 0.0; }
+                            if sp.0.abs() < f64::EPSILON {
+                                sp.1 = 0.0;
+                            }
                             cash += proceeds;
                         }
                     }
 
                     // 记录交易与回调
-                    trades.push((order.id, match order.side { OrderSide::Buy => "BUY".to_string(), OrderSide::Sell => "SELL".to_string() }, exec_price, fill_size));
+                    let side = match order.side {
+                        OrderSide::Buy => "BUY".to_string(),
+                        OrderSide::Sell => "SELL".to_string(),
+                    };
+                    trades.push(TradeRecord {
+                        order_id: order.id,
+                        symbol: order.symbol.clone(),
+                        side: side.clone(),
+                        price: exec_price,
+                        size: fill_size,
+                        datetime: Some(cur_dt.clone()),
+                        commission,
+                    });
                     let trade_evt = PyDict::new_bound(py);
                     trade_evt.set_item("order_id", order.id)?;
-                    trade_evt.set_item("side", match order.side { OrderSide::Buy => "BUY", OrderSide::Sell => "SELL" })?;
+                    trade_evt.set_item("side", side)?;
                     trade_evt.set_item("price", exec_price)?;
                     trade_evt.set_item("size", fill_size)?;
                     trade_evt.set_item("symbol", &order.symbol)?;
+                    trade_evt.set_item("datetime", &cur_dt)?;
+                    trade_evt.set_item("commission", commission)?;
                     let _ = strategy.call_method1(py, "on_trade", (trade_evt.as_any(),));
                 }
             }
@@ -784,7 +1087,9 @@ impl BacktestEngine {
             // 汇总净值并记录
             let mut equity_step: f64 = cash;
             for (sym, (p, _)) in positions.iter() {
-                if let Some(lp) = last_price_map.get(sym) { equity_step += p * lp; }
+                if let Some(lp) = last_price_map.get(sym) {
+                    equity_step += p * lp;
+                }
             }
             equity_curve.push((Some(cur_dt.clone()), equity_step));
             step += 1;
@@ -805,19 +1110,30 @@ impl BacktestEngine {
         let eq_list = PyList::empty_bound(py);
         for (dt, eq) in &equity_curve {
             let row = PyDict::new_bound(py);
-            if let Some(d) = dt { row.set_item("datetime", d)?; } else { row.set_item("datetime", py.None())?; }
+            if let Some(d) = dt {
+                row.set_item("datetime", d)?;
+            } else {
+                row.set_item("datetime", py.None())?;
+            }
             row.set_item("equity", eq)?;
             eq_list.append(row)?;
         }
         result.set_item("equity_curve", eq_list)?;
 
         let tr_list = PyList::empty_bound(py);
-        for (oid, side, price, size) in &trades {
+        for trade in &trades {
             let t = PyDict::new_bound(py);
-            t.set_item("order_id", oid)?;
-            t.set_item("side", side)?;
-            t.set_item("price", price)?;
-            t.set_item("size", size)?;
+            t.set_item("order_id", trade.order_id)?;
+            t.set_item("side", &trade.side)?;
+            t.set_item("price", trade.price)?;
+            t.set_item("size", trade.size)?;
+            t.set_item("symbol", &trade.symbol)?;
+            if let Some(dt) = &trade.datetime {
+                t.set_item("datetime", dt)?;
+            } else {
+                t.set_item("datetime", py.None())?;
+            }
+            t.set_item("commission", trade.commission)?;
             tr_list.append(t)?;
         }
         result.set_item("trades", tr_list)?;
@@ -830,7 +1146,13 @@ impl BacktestEngine {
 }
 
 #[pyfunction]
-fn factor_backtest_fast(py: Python<'_>, closes: Vec<f64>, factors: Vec<f64>, quantiles: usize, forward: usize) -> PyResult<PyObject> {
+fn factor_backtest_fast(
+    py: Python<'_>,
+    closes: Vec<f64>,
+    factors: Vec<f64>,
+    quantiles: usize,
+    forward: usize,
+) -> PyResult<PyObject> {
     let n = closes.len().min(factors.len());
     if quantiles < 2 || forward == 0 || n <= forward {
         let empty = PyDict::new_bound(py);
@@ -874,7 +1196,9 @@ fn factor_backtest_fast(py: Python<'_>, closes: Vec<f64>, factors: Vec<f64>, qua
     for (val, ret) in fac_trim.iter().zip(fwd_returns.iter()) {
         // Find group by linear scan (quantiles is small, typically <= 10)
         let mut gi = 0usize;
-        while gi < q_bounds.len() && *val > q_bounds[gi] { gi += 1; }
+        while gi < q_bounds.len() && *val > q_bounds[gi] {
+            gi += 1;
+        }
         sums[gi] += *ret;
         counts[gi] += 1;
     }
@@ -882,7 +1206,11 @@ fn factor_backtest_fast(py: Python<'_>, closes: Vec<f64>, factors: Vec<f64>, qua
     // Mean returns per quantile
     let mut mean_returns: Vec<f64> = Vec::with_capacity(quantiles);
     for i in 0..quantiles {
-        if counts[i] > 0 { mean_returns.push(sums[i] / counts[i] as f64); } else { mean_returns.push(0.0); }
+        if counts[i] > 0 {
+            mean_returns.push(sums[i] / counts[i] as f64);
+        } else {
+            mean_returns.push(0.0);
+        }
     }
 
     // IC: Pearson correlation between fac_trim and fwd_returns
@@ -908,12 +1236,20 @@ fn factor_backtest_fast(py: Python<'_>, closes: Vec<f64>, factors: Vec<f64>, qua
     let mut dec = 0i32;
     if mean_returns.len() > 1 {
         for i in 1..mean_returns.len() {
-            if mean_returns[i] > mean_returns[i - 1] { inc += 1; }
-            if mean_returns[i] < mean_returns[i - 1] { dec += 1; }
+            if mean_returns[i] > mean_returns[i - 1] {
+                inc += 1;
+            }
+            if mean_returns[i] < mean_returns[i - 1] {
+                dec += 1;
+            }
         }
     }
     let denom_m = (mean_returns.len().saturating_sub(1)) as f64;
-    let monotonicity = if denom_m > 0.0 { (inc - dec) as f64 / denom_m } else { 0.0 };
+    let monotonicity = if denom_m > 0.0 {
+        (inc - dec) as f64 / denom_m
+    } else {
+        0.0
+    };
 
     // Factor stats
     let min_f = fac_trim
@@ -927,25 +1263,36 @@ fn factor_backtest_fast(py: Python<'_>, closes: Vec<f64>, factors: Vec<f64>, qua
     let mean_f_all = mean_f;
     let std_f = if m > 1 {
         let mut vs = 0.0_f64;
-        for v in fac_trim.iter() { let d = *v - mean_f_all; vs += d * d; }
+        for v in fac_trim.iter() {
+            let d = *v - mean_f_all;
+            vs += d * d;
+        }
         (vs / m as f64).sqrt()
-    } else { 0.0 };
+    } else {
+        0.0
+    };
 
     // Build Python result dict
     let out = PyDict::new_bound(py);
     let q_list = PyList::empty_bound(py);
-    for i in 1..=quantiles { q_list.append(i as i32)?; }
+    for i in 1..=quantiles {
+        q_list.append(i as i32)?;
+    }
     out.set_item("quantiles", q_list)?;
 
     let mr_list = PyList::empty_bound(py);
-    for v in mean_returns.iter() { mr_list.append(*v)?; }
+    for v in mean_returns.iter() {
+        mr_list.append(*v)?;
+    }
     out.set_item("mean_returns", mr_list)?;
 
     out.set_item("ic", ic)?;
     out.set_item("monotonicity", monotonicity)?;
 
     let qb_list = PyList::empty_bound(py);
-    for v in q_bounds.iter() { qb_list.append(*v)?; }
+    for v in q_bounds.iter() {
+        qb_list.append(*v)?;
+    }
     out.set_item("q_bounds", qb_list)?;
 
     let fs = PyDict::new_bound(py);
@@ -972,4 +1319,4 @@ fn engine_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(database::save_klines, m)?)?;
     m.add_function(wrap_pyfunction!(database::save_klines_from_csv, m)?)?;
     Ok(())
-} 
+}

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PYTHON_DIR = os.path.join(ROOT, "python")
+if PYTHON_DIR not in sys.path:
+    sys.path.insert(0, PYTHON_DIR)
+
+try:
+    from engine_rust import compute_sma
+    from pyrust_bt.api import BacktestConfig, BacktestEngine
+    from pyrust_bt.strategy import Strategy
+
+    IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - depends on local build state
+    compute_sma = None
+    BacktestConfig = None
+    BacktestEngine = None
+    Strategy = object
+    IMPORT_ERROR = exc
+
+
+def make_bars(symbol: str = "TEST"):
+    return [
+        {
+            "datetime": "2024-01-01 09:30:00",
+            "open": 10.0,
+            "high": 10.5,
+            "low": 9.5,
+            "close": 10.0,
+            "volume": 1000.0,
+            "symbol": symbol,
+        },
+        {
+            "datetime": "2024-01-01 09:31:00",
+            "open": 10.0,
+            "high": 12.5,
+            "low": 9.8,
+            "close": 12.0,
+            "volume": 1000.0,
+            "symbol": symbol,
+        },
+    ]
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"engine_rust is not built: {IMPORT_ERROR}")
+class EngineCoreTests(unittest.TestCase):
+    def make_engine(self):
+        cfg = BacktestConfig(
+            start="2024-01-01",
+            end="2024-01-02",
+            cash=1000.0,
+            commission_rate=0.001,
+            slippage_bps=0.0,
+        )
+        return BacktestEngine(cfg)
+
+    def test_compute_sma_window_alignment(self):
+        self.assertEqual(compute_sma([1.0, 2.0, 3.0, 4.0], 3), [None, None, 2.0, 3.0])
+
+    def test_single_asset_final_equity_uses_last_equity_curve_value(self):
+        class BuyOnceStrategy(Strategy):
+            def __init__(self):
+                self.done = False
+
+            def next(self, bar, ctx):
+                if self.done:
+                    return None
+                self.done = True
+                return {"action": "BUY", "type": "market", "size": 1.0}
+
+        result = self.make_engine().run(BuyOnceStrategy(), make_bars())
+        self.assertAlmostEqual(result["equity"], result["equity_curve"][-1]["equity"])
+
+    def test_strategy_exception_is_propagated(self):
+        class RaisingStrategy(Strategy):
+            def next(self, bar, ctx):
+                raise ValueError("intentional strategy failure")
+
+        with self.assertRaisesRegex(ValueError, "intentional strategy failure"):
+            self.make_engine().run(RaisingStrategy(), make_bars())
+
+    def test_one_arg_strategy_still_works(self):
+        class OneArgStrategy(Strategy):
+            def next(self, bar):
+                return {"action": "BUY", "type": "market", "size": 1.0}
+
+        result = self.make_engine().run(OneArgStrategy(), make_bars())
+        self.assertGreaterEqual(len(result["trades"]), 1)
+
+    def test_trade_records_include_metadata(self):
+        class BuyOnceStrategy(Strategy):
+            def __init__(self):
+                self.done = False
+
+            def next(self, bar):
+                if self.done:
+                    return None
+                self.done = True
+                return {"action": "BUY", "type": "market", "size": 1.0}
+
+        result = self.make_engine().run(BuyOnceStrategy(), make_bars(symbol="SINGLE"))
+        trade = result["trades"][0]
+
+        for key in ("order_id", "side", "price", "size", "symbol", "datetime", "commission"):
+            self.assertIn(key, trade)
+        self.assertEqual(trade["symbol"], "SINGLE")
+        self.assertEqual(trade["datetime"], "2024-01-01 09:30:00")
+        self.assertAlmostEqual(trade["commission"], 0.01)
+
+    def test_multi_asset_trade_records_include_symbol(self):
+        class MultiBuyStrategy(Strategy):
+            def __init__(self):
+                self.done = False
+
+            def next_multi(self, update_slice, ctx):
+                if self.done:
+                    return None
+                self.done = True
+                return [
+                    {"action": "BUY", "type": "market", "size": 1.0, "symbol": "AAA"},
+                    {"action": "BUY", "type": "market", "size": 1.0, "symbol": "BBB"},
+                ]
+
+        feeds = {
+            "AAA": make_bars(symbol="AAA"),
+            "BBB": make_bars(symbol="BBB"),
+        }
+        result = self.make_engine().run_multi(MultiBuyStrategy(), feeds)
+        symbols = {trade["symbol"] for trade in result["trades"]}
+
+        self.assertEqual(symbols, {"AAA", "BBB"})
+        for trade in result["trades"]:
+            self.assertIn("datetime", trade)
+            self.assertIn("commission", trade)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed Rust SMA window alignment in lib.rs:117.
Fixed single-asset final result["equity"] to use the last equity-curve value instead of treating equity as price in lib.rs:674. Added TradeRecord with symbol, datetime, and commission while preserving order_id, side, price, and size in lib.rs:87. Reworked strategy invocation so next(bar) vs next(bar, ctx) is selected up front with inspect.signature, avoiding swallowed strategy exceptions in lib.rs:461. Changed multi-asset fallback behavior so next_multi errors propagate instead of being silently converted into next() fallback in lib.rs:878. Added unittest coverage in test_engine_core.py:51.